### PR TITLE
Add functions to wrap the logger

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x]
+        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,27 @@
+package ntest_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/memsql/ntest"
+)
+
+var _ ntest.T = &testing.T{}
+
+func TestPrefixLogger(t *testing.T) {
+	var caught []string
+	captureT := ntest.ReplaceLogger(t, func(s string) {
+		t.Log("captured:", s)
+		caught = append(caught, s)
+	})
+	extraDetail := ntest.ExtraDetailLogger(captureT, "some-prefix")
+	extraDetail.Log("not-formatted", 3)
+	extraDetail.Logf("formatted '%s'", "quoted")
+
+	require.Equal(t, 2, len(caught), "len caught")
+	assert.Regexp(t, `some-prefix \d\d:\d\d:\d\d not-formatted 3$`, caught[0], "unformatted")
+	assert.Regexp(t, `some-prefix \d\d:\d\d:\d\d formatted 'quoted'$`, caught[1], "formatted")
+}

--- a/t.go
+++ b/t.go
@@ -1,5 +1,10 @@
 package ntest
 
+import (
+	"fmt"
+	"time"
+)
+
 // T is subset of what testing.T provides and is also a subset of
 // of what ginkgo.GinkgoT() provides.  This interface is probably
 // richer than strictly required so more could be removed from it
@@ -20,4 +25,35 @@ type T interface {
 	Skip(args ...interface{})
 	Skipf(format string, args ...interface{})
 	Skipped() bool
+}
+
+type logWrappedT struct {
+	T
+	logger func(string)
+}
+
+// ReplaceLogger creates a T that is wrapped so that the logger is
+// overridden with the provided function.
+func ReplaceLogger(t T, logger func(string)) T {
+	return logWrappedT{
+		T:      t,
+		logger: logger,
+	}
+}
+
+func (t logWrappedT) Log(args ...interface{}) {
+	line := fmt.Sprintln(args...)
+	t.logger(line[0 : len(line)-1])
+}
+
+func (t logWrappedT) Logf(format string, args ...interface{}) {
+	t.logger(fmt.Sprintf(format, args...))
+}
+
+// ExtraDetailLogger creates a T that wraps the logger to add both a
+// prefix and a timestamp to each line that is logged.
+func ExtraDetailLogger(t T, prefix string) T {
+	return ReplaceLogger(t, func(s string) {
+		t.Log(prefix, time.Now().Format("15:04:05"), s)
+	})
 }

--- a/test_test.go
+++ b/test_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/memsql/ntest"
 	"github.com/muir/nject"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/memsql/ntest"
 )
 
 func TestRun(t *testing.T) {


### PR DESCRIPTION
This adds a couple of functions that can be used to override the logger in a test.