### PR TITLE
[feat] add buffered logger that emulates non -v test output

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,159 @@
+package ntest
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type logWrappedT struct {
+	T
+	logger func(string)
+}
+
+// ReplaceLogger creates a T that is wrapped so that the logger is
+// overridden with the provided function.
+func ReplaceLogger(t T, logger func(string)) T {
+	return logWrappedT{
+		T:      t,
+		logger: logger,
+	}
+}
+
+func (t logWrappedT) Log(args ...interface{}) {
+	line := fmt.Sprintln(args...)
+	t.logger(line[0 : len(line)-1])
+}
+
+func (t logWrappedT) Logf(format string, args ...interface{}) {
+	t.logger(fmt.Sprintf(format, args...))
+}
+
+// AdjustSkipFrames adjusts skip frames on the underlying T if it supports it
+func (t logWrappedT) AdjustSkipFrames(skip int) {
+	if adjuster, ok := t.T.(interface{ AdjustSkipFrames(int) }); ok {
+		adjuster.AdjustSkipFrames(skip)
+	}
+}
+
+// ExtraDetailLogger creates a T that wraps the logger to add both a
+// prefix and a timestamp to each line that is logged.
+func ExtraDetailLogger(t T, prefix string) T {
+	// First, adjust skip frames on the underlying T if it supports it
+	// We need to skip 2 additional frames: the lambda function and the ReplaceLogger wrapper
+	if adjuster, ok := t.(interface{ AdjustSkipFrames(int) }); ok {
+		adjuster.AdjustSkipFrames(2)
+	}
+
+	wrapped := ReplaceLogger(t, func(s string) {
+		t.Log(prefix, time.Now().Format("15:04:05"), s)
+	})
+
+	return wrapped
+}
+
+type bufferedLogEntry struct {
+	message  string
+	file     string
+	line     int
+	function string
+}
+
+type bufferedLogWrappedT struct {
+	T
+	entries    []bufferedLogEntry
+	skipFrames int // Number of additional stack frames to skip
+}
+
+// AdjustSkipFrames changes the number of stack frames to skip when capturing caller info
+func (t *bufferedLogWrappedT) AdjustSkipFrames(skip int) {
+	t.skipFrames = skip
+}
+
+// BufferedLogger creates a T that buffers all log output and only
+// outputs it during test cleanup if the test failed. Each log entry
+// includes the filename and line number where the log was called.
+// The purpose of this is for situations where go tests are defaulting
+// to -v but output should be supressed anyway.
+//
+// If the environment variable NTEST_BUFFERING is set to "false", buffering
+// will be turned off.
+func BufferedLogger(t T) T {
+	if os.Getenv("NTEST_BUFFERING") == "false" {
+		return t
+	}
+	wrapped := &bufferedLogWrappedT{
+		T:          t,
+		entries:    make([]bufferedLogEntry, 0),
+		skipFrames: 0,
+	}
+
+	// Register cleanup function to output buffered logs if test failed
+	t.Cleanup(func() {
+		if t.Failed() && len(wrapped.entries) > 0 {
+			var buffer strings.Builder
+			var size int
+			for _, entry := range wrapped.entries {
+				size += 9 + len(entry.file) + len(entry.message)
+			}
+			buffer.Grow(size)
+			_, _ = buffer.Write([]byte("=== Buffered Log Output (test failed) ===\n"))
+			for _, entry := range wrapped.entries {
+				_, _ = fmt.Fprintf(&buffer, "%s:%d %s\n", entry.file, entry.line, entry.message)
+			}
+			_, _ = buffer.Write([]byte("=== End Buffered Log Output ===\n"))
+			t.Log(buffer.String())
+		} else {
+			t.Logf("dropping %d log entries (test passed)", len(wrapped.entries))
+		}
+	})
+
+	return wrapped
+}
+
+func (t *bufferedLogWrappedT) addLogEntry(message string) {
+	// Get caller information (skip 2 frames + additional skipFrames: this function and the Log/Logf wrapper + any additional)
+	pc, file, line, ok := runtime.Caller(2 + t.skipFrames)
+	if !ok {
+		file = "unknown"
+		line = 0
+	} else {
+		// Get just the filename, not the full path
+		if idx := strings.LastIndex(file, "/"); idx >= 0 {
+			file = file[idx+1:]
+		}
+	}
+
+	var function string
+	if pc != 0 {
+		if fn := runtime.FuncForPC(pc); fn != nil {
+			function = fn.Name()
+			// Strip package path from function name
+			if idx := strings.LastIndex(function, "."); idx >= 0 {
+				function = function[idx+1:]
+			}
+		}
+	}
+
+	entry := bufferedLogEntry{
+		message:  message,
+		file:     file,
+		line:     line,
+		function: function,
+	}
+
+	t.entries = append(t.entries, entry)
+}
+
+func (t *bufferedLogWrappedT) Log(args ...interface{}) {
+	line := fmt.Sprintln(args...)
+	message := line[0 : len(line)-1] // Remove trailing newline
+	t.addLogEntry(message)
+}
+
+func (t *bufferedLogWrappedT) Logf(format string, args ...interface{}) {
+	message := fmt.Sprintf(format, args...)
+	t.addLogEntry(message)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,6 +1,10 @@
 package ntest_test
 
 import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,16 +16,287 @@ import (
 var _ ntest.T = &testing.T{}
 
 func TestPrefixLogger(t *testing.T) {
+	t.Log("Testing ExtraDetailLogger with prefix functionality")
+
 	var caught []string
 	captureT := ntest.ReplaceLogger(t, func(s string) {
 		t.Log("captured:", s)
 		caught = append(caught, s)
 	})
+
+	t.Log("Creating ExtraDetailLogger with prefix 'some-prefix'")
 	extraDetail := ntest.ExtraDetailLogger(captureT, "some-prefix")
+
+	t.Log("Logging unformatted message")
 	extraDetail.Log("not-formatted", 3)
+
+	t.Log("Logging formatted message")
 	extraDetail.Logf("formatted '%s'", "quoted")
+
+	t.Logf("Captured %d log entries", len(caught))
+	for i, entry := range caught {
+		t.Logf("Entry %d: %s", i, entry)
+	}
 
 	require.Equal(t, 2, len(caught), "len caught")
 	assert.Regexp(t, `some-prefix \d\d:\d\d:\d\d not-formatted 3$`, caught[0], "unformatted")
 	assert.Regexp(t, `some-prefix \d\d:\d\d:\d\d formatted 'quoted'$`, caught[1], "formatted")
+
+	t.Log("ExtraDetailLogger test completed successfully")
+}
+
+func TestBufferedLogger_PassingTest(t *testing.T) {
+	t.Log("Testing BufferedLogger with passing test (should suppress all logs)")
+
+	var captured []string
+	captureT := ntest.ReplaceLogger(t, func(s string) {
+		captured = append(captured, s)
+	})
+
+	t.Log("Creating BufferedLogger")
+	buffered := ntest.BufferedLogger(captureT)
+
+	t.Log("Adding logs that should be suppressed")
+	buffered.Log("This should not appear")
+	buffered.Logf("Neither should this: %d", 42)
+
+	t.Logf("Captured %d entries (should be 0 for passing test)", len(captured))
+	for i, entry := range captured {
+		t.Logf("Unexpected entry %d: %s", i, entry)
+	}
+
+	// Since the test passes, no logs should be captured
+	assert.Equal(t, 0, len(captured), "no logs should be captured for passing test")
+	t.Log("BufferedLogger passing test completed successfully")
+}
+
+func TestBufferedLogger_FailingTest(t *testing.T) {
+	t.Log("Testing BufferedLogger with failing test (should output buffered logs)")
+
+	// Create a mock T that reports as failed
+	mockT := newMockedT("TestBufferedLogger_FailingTest")
+	t.Log("Created mockedT with name:", mockT.Name())
+
+	t.Log("Creating BufferedLogger")
+	buffered := ntest.BufferedLogger(mockT)
+
+	t.Log("Adding logs that should be buffered and later output")
+	buffered.Log("This should appear")
+	buffered.Logf("This too: %d", 42)
+
+	t.Log("Setting test as failed and triggering cleanup")
+	mockT.setFailed()
+	mockT.triggerCleanup()
+
+	t.Logf("After cleanup, captured %d log entries", len(mockT.captured))
+	for i, entry := range mockT.captured {
+		t.Logf("Captured entry %d: %s", i, entry)
+	}
+
+	// Check that logs contain file:line information
+	found := false
+	for _, log := range mockT.captured {
+		if strings.Contains(log, "logger_test.go:") && strings.Contains(log, "This should appear") {
+			found = true
+			t.Logf("Found expected log with file:line info: %s", log)
+			break
+		}
+	}
+	assert.True(t, found, "should contain filename and line number")
+	t.Log("BufferedLogger failing test completed successfully")
+}
+
+// Test line number accuracy for BufferedLogger
+func TestBufferedLogger_LineNumberAccuracy(t *testing.T) {
+	t.Log("Testing BufferedLogger line number accuracy using runtime.Caller")
+
+	mockT := newMockedT("TestBufferedLogger_LineNumberAccuracy")
+	buffered := ntest.BufferedLogger(mockT)
+
+	// Get the current line number for reference
+	_, _, currentLine, _ := runtime.Caller(0)
+	t.Logf("Current line number is %d", currentLine)
+
+	buffered.Log("Test message 1") // This should capture this line
+	logLine1 := currentLine + 3
+	t.Logf("Expected line number for 'Test message 1': %d", logLine1)
+
+	buffered.Logf("Test message %d", 2) // This should capture this line
+	logLine2 := currentLine + 7
+	t.Logf("Expected line number for 'Test message 2': %d", logLine2)
+
+	// Set failed and trigger cleanup
+	t.Log("Setting test as failed and triggering cleanup")
+	mockT.setFailed()
+	mockT.triggerCleanup()
+
+	t.Logf("After cleanup, captured %d log entries", len(mockT.captured))
+	for i, entry := range mockT.captured {
+		t.Logf("Captured entry %d: %s", i, entry)
+	}
+
+	// Find the captured log entries with line numbers
+	found1, found2 := false, false
+	expectedLine1 := strconv.Itoa(logLine1)
+	expectedLine2 := strconv.Itoa(logLine2)
+
+	t.Logf("Looking for line numbers: %s and %s", expectedLine1, expectedLine2)
+
+	for _, log := range mockT.captured {
+		if strings.Contains(log, "Test message 1") && strings.Contains(log, "logger_test.go:"+expectedLine1) {
+			found1 = true
+			t.Logf("✓ Found Test message 1 with correct line number: %s", log)
+		}
+		if strings.Contains(log, "Test message 2") && strings.Contains(log, "logger_test.go:"+expectedLine2) {
+			found2 = true
+			t.Logf("✓ Found Test message 2 with correct line number: %s", log)
+		}
+	}
+
+	assert.True(t, found1, "Should find Test message 1 with correct line number %s", expectedLine1)
+	assert.True(t, found2, "Should find Test message 2 with correct line number %s", expectedLine2)
+	t.Log("BufferedLogger line number accuracy test completed")
+}
+
+// Test line number accuracy for ExtraDetailLogger with BufferedLogger
+func TestExtraDetailLogger_WithBufferedLogger_LineNumberAccuracy(t *testing.T) {
+	t.Log("Testing ExtraDetailLogger with BufferedLogger for line number accuracy")
+
+	mockT := newMockedT("TestExtraDetailLogger_LineNumberAccuracy")
+	t.Log("Created mockedT")
+
+	buffered := ntest.BufferedLogger(mockT)
+	t.Log("Created BufferedLogger")
+
+	extraDetail := ntest.ExtraDetailLogger(buffered, "PREFIX")
+	t.Log("Created ExtraDetailLogger with prefix 'PREFIX'")
+
+	// Get the current line number for reference
+	_, _, currentLine, _ := runtime.Caller(0)
+	t.Logf("Current line number is %d", currentLine)
+
+	extraDetail.Log("Test message from extra detail") // This should capture this line
+	logLine := currentLine + 3
+	t.Logf("Expected line number for log message: %d", logLine)
+
+	// Set failed and trigger cleanup
+	t.Log("Setting test as failed and triggering cleanup")
+	mockT.setFailed()
+	mockT.triggerCleanup()
+
+	t.Logf("After cleanup, captured %d log entries", len(mockT.captured))
+	for i, entry := range mockT.captured {
+		t.Logf("Captured entry %d: %s", i, entry)
+	}
+
+	// Find the captured log entry with correct line number
+	found := false
+	expectedLine := strconv.Itoa(logLine)
+	t.Logf("Looking for line number: %s", expectedLine)
+
+	for _, log := range mockT.captured {
+		if strings.Contains(log, "Test message from extra detail") && strings.Contains(log, "logger_test.go:"+expectedLine) {
+			found = true
+			t.Logf("✓ Found log message with correct line number: %s", log)
+			break
+		}
+	}
+
+	assert.True(t, found, "Should find log message with correct line number %s", expectedLine)
+	t.Log("ExtraDetailLogger line number accuracy test completed")
+}
+
+// Mock T implementation for testing with log capture capabilities
+type mockedT struct {
+	ntest.T
+	failed   bool
+	cleanups []func()
+	captured []string
+	skipped  bool
+	name     string
+	envs     map[string]string
+}
+
+func newMockedT(name string) *mockedT {
+	return &mockedT{
+		name:     name,
+		envs:     make(map[string]string),
+		captured: make([]string, 0),
+		cleanups: make([]func(), 0),
+	}
+}
+
+func (m *mockedT) Failed() bool {
+	return m.failed
+}
+
+func (m *mockedT) Skipped() bool {
+	return m.skipped
+}
+
+func (m *mockedT) Name() string {
+	return m.name
+}
+
+func (m *mockedT) Cleanup(f func()) {
+	m.cleanups = append(m.cleanups, f)
+}
+
+func (m *mockedT) Helper() {
+	// No-op for mock
+}
+
+func (m *mockedT) FailNow() {
+	m.failed = true
+}
+
+func (m *mockedT) Skip(args ...interface{}) {
+	m.skipped = true
+}
+
+func (m *mockedT) Skipf(format string, args ...interface{}) {
+	m.skipped = true
+}
+
+func (m *mockedT) Log(args ...interface{}) {
+	line := fmt.Sprintln(args...)
+	m.captured = append(m.captured, strings.TrimSpace(line))
+}
+
+func (m *mockedT) Logf(format string, args ...interface{}) {
+	m.captured = append(m.captured, fmt.Sprintf(format, args...))
+}
+
+func (m *mockedT) Error(args ...interface{}) {
+	m.Log(args...)
+	m.failed = true
+}
+
+func (m *mockedT) Errorf(format string, args ...interface{}) {
+	m.Logf(format, args...)
+	m.failed = true
+}
+
+func (m *mockedT) Fatal(args ...interface{}) {
+	m.Log(args...)
+	m.failed = true
+}
+
+func (m *mockedT) Fatalf(format string, args ...interface{}) {
+	m.Logf(format, args...)
+	m.failed = true
+}
+
+func (m *mockedT) Setenv(key, value string) {
+	m.envs[key] = value
+}
+
+func (m *mockedT) triggerCleanup() {
+	for _, cleanup := range m.cleanups {
+		cleanup()
+	}
+}
+
+func (m *mockedT) setFailed() {
+	m.failed = true
 }

--- a/t.go
+++ b/t.go
@@ -1,10 +1,5 @@
 package ntest
 
-import (
-	"fmt"
-	"time"
-)
-
 // T is subset of what testing.T provides and is also a subset of
 // of what ginkgo.GinkgoT() provides.  This interface is probably
 // richer than strictly required so more could be removed from it
@@ -25,35 +20,4 @@ type T interface {
 	Skip(args ...interface{})
 	Skipf(format string, args ...interface{})
 	Skipped() bool
-}
-
-type logWrappedT struct {
-	T
-	logger func(string)
-}
-
-// ReplaceLogger creates a T that is wrapped so that the logger is
-// overridden with the provided function.
-func ReplaceLogger(t T, logger func(string)) T {
-	return logWrappedT{
-		T:      t,
-		logger: logger,
-	}
-}
-
-func (t logWrappedT) Log(args ...interface{}) {
-	line := fmt.Sprintln(args...)
-	t.logger(line[0 : len(line)-1])
-}
-
-func (t logWrappedT) Logf(format string, args ...interface{}) {
-	t.logger(fmt.Sprintf(format, args...))
-}
-
-// ExtraDetailLogger creates a T that wraps the logger to add both a
-// prefix and a timestamp to each line that is logged.
-func ExtraDetailLogger(t T, prefix string) T {
-	return ReplaceLogger(t, func(s string) {
-		t.Log(prefix, time.Now().Format("15:04:05"), s)
-	})
 }


### PR DESCRIPTION
This adds a very special purpose buffered logger that emulates the behavior of "go test" (without -v)