### PR TITLE
[feat] Support matrix testing with BufferedLogger (BREAKING CHANGE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ This is easily handled with `t.Cleanup()`
 ## Abort vs nject.TerminalError
 
 If the injection chains used in tests are only used in tests, then when
-something goes wrong in an injector, it can simply abort (`t.FailNow()`) the test.
+something goes wrong in an injector, it can simply abort (`t.Fail()`) the test.
 
 If the injection chains are shared with non-test code, then instead
 of aborting, injectors can return

--- a/logger.go
+++ b/logger.go
@@ -224,7 +224,7 @@ func AsRunT[ET T](t ET) RunT {
 	return NewTestRunner(t)
 }
 
-// ReWrapper allows types to recreate themselves with a fresh *testing.T
+// ReWrapper allows types that wrap T to recreate themselves from fresh *testing.T
 // This enables proper sub-test handling in matrix testing while preserving wrapper behavior
 type ReWrapper interface {
 	ReWrap(*testing.T) T

--- a/logger.go
+++ b/logger.go
@@ -212,15 +212,3 @@ func BufferedLogger[ET T](t ET) T {
 
 	return wrapped // Return by reference so AdjustSkipFrames works
 }
-
-// AsRunT upgrades a T to RunT for use with matrix testing.
-// Use this helper when you have a T and need to use it with matrix testing functions.
-func AsRunT[ET T](t ET) RunT {
-	// If t already implements RunT, return it directly
-	if runT, ok := any(t).(RunT); ok {
-		return runT
-	}
-
-	// Otherwise, wrap it using NewTestRunner
-	return NewTestRunner(t)
-}

--- a/logger.go
+++ b/logger.go
@@ -55,7 +55,7 @@ func (t loggerT[ET]) Logf(format string, args ...interface{}) {
 // Note: This passes the raw *testing.T to the function, losing logger wrapping.
 // Use RunWithReWrap instead if you need to preserve logger wrapping in subtests.
 func (t loggerT[ET]) Run(name string, f func(*testing.T)) bool {
-	if runnable, ok := any(t.T).(interface {
+	if runnable, ok := t.T.(interface {
 		Run(string, func(*testing.T)) bool
 	}); ok {
 		return runnable.Run(name, f)
@@ -69,7 +69,7 @@ func (t loggerT[ET]) Run(name string, f func(*testing.T)) bool {
 
 // ReWrap implements ReWrapper to recreate loggerT with fresh T
 func (t loggerT[ET]) ReWrap(newT T) T {
-	if reWrapper, ok := any(t.T).(ReWrapper); ok {
+	if reWrapper, ok := t.T.(ReWrapper); ok {
 		rewrapped := reWrapper.ReWrap(newT)
 		return ReplaceLogger(rewrapped, t.logger)
 	}
@@ -80,7 +80,7 @@ func (t loggerT[ET]) ReWrap(newT T) T {
 func (t *loggerT[ET]) AdjustSkipFrames(skip int) {
 	t.skipFrames += skip
 	// Also forward to the underlying T if it supports AdjustSkipFrames
-	if adjuster, ok := any(t.T).(interface{ AdjustSkipFrames(int) }); ok {
+	if adjuster, ok := t.T.(interface{ AdjustSkipFrames(int) }); ok {
 		adjuster.AdjustSkipFrames(skip)
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -223,9 +223,3 @@ func AsRunT[ET T](t ET) RunT {
 	// Otherwise, wrap it using NewTestRunner
 	return NewTestRunner(t)
 }
-
-// ReWrapper allows types that wrap T to recreate themselves from fresh T
-// This enables proper sub-test handling in matrix testing while preserving wrapper behavior
-type ReWrapper interface {
-	ReWrap(T) T
-}

--- a/logger.go
+++ b/logger.go
@@ -37,11 +37,10 @@ func ReplaceLogger[ET T](t ET, logger func(string)) T {
 		adjuster.AdjustSkipFrames(2) // +2 for replaceLoggerT.Log and the custom logger function
 	}
 
-	wrapped := &replaceLoggerT[ET]{
+	return &replaceLoggerT[ET]{
 		T:      t,
 		logger: logger,
 	}
-	return any(wrapped).(T)
 }
 
 func (t replaceLoggerT[ET]) Log(args ...interface{}) {

--- a/logger.go
+++ b/logger.go
@@ -8,45 +8,45 @@ import (
 	"time"
 )
 
-type logWrappedT[ET T] struct {
+type LoggerT[ET T] struct {
 	runTHelper    // Embeds T and provides Fail/Parallel
 	orig       ET // Keep reference to original for Run method
 	logger     func(string)
 }
 
-// ReplaceLogger creates a T that is wrapped so that the logger is
-// overridden with the provided function.
-func ReplaceLogger[ET T](t ET, logger func(string)) T {
-	self := logWrappedT[ET]{
+// ReplaceLogger creates a logger wrapper that overrides the logging function.
+// Returns RunT[LoggerT] for consistency with other logger wrappers.
+func ReplaceLogger[ET T](t ET, logger func(string)) RunT[LoggerT[ET]] {
+	wrapped := LoggerT[ET]{
 		runTHelper: runTHelper{T: t}, // Set the embedded helper
 		orig:       t,                // Keep reference to original
 		logger:     logger,
 	}
-	return self
+	return wrapped // LoggerT[ET] implements RunT[LoggerT[ET]]
 }
 
-func (t logWrappedT[ET]) Log(args ...interface{}) {
+func (t LoggerT[ET]) Log(args ...interface{}) {
 	line := fmt.Sprintln(args...)
 	t.logger(line[0 : len(line)-1])
 }
 
-func (t logWrappedT[ET]) Logf(format string, args ...interface{}) {
+func (t LoggerT[ET]) Logf(format string, args ...interface{}) {
 	t.logger(fmt.Sprintf(format, args...))
 }
 
 // AdjustSkipFrames adjusts skip frames on the underlying T if it supports it
-// logWrappedT adds 2 frames (Log/Logf method + the lambda function call)
-func (t logWrappedT[ET]) AdjustSkipFrames(skip int) {
+// LoggerT adds 2 frames (Log/Logf method + the lambda function call)
+func (t LoggerT[ET]) AdjustSkipFrames(skip int) {
 	if adjuster, ok := any(t.orig).(interface{ AdjustSkipFrames(int) }); ok {
-		adjuster.AdjustSkipFrames(skip + 2) // +2 for logWrappedT.Log/Logf + lambda function
+		adjuster.AdjustSkipFrames(skip + 2) // +2 for LoggerT.Log/Logf + lambda function
 	}
 }
 
 // RunT methods
-func (t logWrappedT[ET]) Run(name string, f func(logWrappedT[ET])) bool {
+func (t LoggerT[ET]) Run(name string, f func(LoggerT[ET])) bool {
 	if runT, ok := any(t.orig).(RunT[ET]); ok {
 		return runT.Run(name, func(innerT ET) {
-			inner := logWrappedT[ET]{
+			inner := LoggerT[ET]{
 				runTHelper: runTHelper{T: innerT},
 				orig:       innerT,
 				logger:     t.logger,
@@ -61,24 +61,25 @@ func (t logWrappedT[ET]) Run(name string, f func(logWrappedT[ET])) bool {
 
 // ExtraDetailLogger creates a logger wrapper that adds both a
 // prefix and a timestamp to each line that is logged.
-// Returns logWrappedT which implements RunT for use with matrix testing.
-func ExtraDetailLogger[ET T](t ET, prefix string) logWrappedT[ET] {
+// Returns RunT[LoggerT] which implements RunT for use with matrix testing.
+func ExtraDetailLogger[ET T](t ET, prefix string) RunT[LoggerT[ET]] {
 	logger := func(s string) {
 		t.Log(prefix, time.Now().Format("15:04:05"), s)
 	}
 
-	wrapped := logWrappedT[ET]{
+	wrapped := LoggerT[ET]{
 		runTHelper: runTHelper{T: t}, // Set the embedded helper
 		orig:       t,                // Keep reference to original
 		logger:     logger,
 	}
 
-	// Adjust skip frames on the underlying T to account for our wrapper
+	// Adjust skip frames on the underlying T to account for our lambda function
+	// ExtraDetailLogger adds 1 extra frame (the lambda function call)
 	if adjuster, ok := any(t).(interface{ AdjustSkipFrames(int) }); ok {
-		adjuster.AdjustSkipFrames(0) // This will add 2 frames via logWrappedT.AdjustSkipFrames
+		adjuster.AdjustSkipFrames(1) // +1 for the lambda function call in ExtraDetailLogger
 	}
 
-	return wrapped
+	return wrapped // LoggerT[ET] implements RunT[LoggerT[ET]]
 }
 
 type bufferedLogEntry struct {
@@ -88,158 +89,92 @@ type bufferedLogEntry struct {
 	function string
 }
 
-// BufferedLogWrappedT is the type returned by BufferedLogger
-type BufferedLogWrappedT[ET T] struct {
-	runTHelper    // Embeds T and provides Fail/Parallel
-	orig       ET // Keep reference to original for Run method
-	entries    []bufferedLogEntry
-	skipFrames int  // Number of additional stack frames to skip
-	disabled   bool // Whether buffering is disabled
-}
-
-// AdjustSkipFrames changes the number of stack frames to skip when capturing caller info
-// BufferedLogWrappedT adds 2 frames (Log/Logf → addLogEntry)
-func (t *BufferedLogWrappedT[ET]) AdjustSkipFrames(skip int) {
-	t.skipFrames = skip + 2 // +2 for BufferedLogWrappedT.Log/Logf → addLogEntry
-}
-
-// RunT methods
-func (t *BufferedLogWrappedT[ET]) Run(name string, f func(*BufferedLogWrappedT[ET])) bool {
-	if runT, ok := any(t.orig).(RunT[ET]); ok {
-		return runT.Run(name, func(innerT ET) {
-			inner := &BufferedLogWrappedT[ET]{
-				runTHelper: runTHelper{T: innerT},
-				orig:       innerT,
-				entries:    make([]bufferedLogEntry, 0),
-				skipFrames: t.skipFrames,
-				disabled:   t.disabled,
-			}
-			f(inner)
-		})
-	}
-	t.T.Logf("Run not supported by %T", t.orig)
-	t.T.FailNow()
-	return false
-}
-
-// BufferedLogger creates a T that buffers all log output and only
-// outputs it during test cleanup if the test failed. Each log entry
-// includes the filename and line number where the log was called.
-// The purpose of this is for situations where go tests are defaulting
-// to -v but output should be supressed anyway.
-//
-// If the environment variable NTEST_BUFFERING is set to "false", buffering
-// will be turned off.
-// BufferedLoggerT returns a BufferedLogger that implements RunT for matrix testing
-func BufferedLoggerT[ET T](t ET) *BufferedLogWrappedT[ET] {
+// createBufferedLogger creates a logger function that buffers log entries
+// and outputs them during cleanup if the test fails
+func createBufferedLogger[ET T](t ET, skipFrames int) func(string) {
 	if os.Getenv("NTEST_BUFFERING") == "false" {
-		// When buffering is disabled, we still need to return the wrapper type
-		// but we'll make it pass through to the underlying T directly
-		return &BufferedLogWrappedT[ET]{
-			runTHelper: runTHelper{T: t},
-			orig:       t,
-			entries:    make([]bufferedLogEntry, 0),
-			skipFrames: 0,
-			disabled:   true, // Mark as disabled
+		// When buffering is disabled, pass through to original logger
+		return func(message string) {
+			t.Log(message)
 		}
 	}
 
-	wrapped := &BufferedLogWrappedT[ET]{
-		runTHelper: runTHelper{T: t},
-		orig:       t,
-		entries:    make([]bufferedLogEntry, 0),
-		skipFrames: 0,
-		disabled:   false,
-	}
+	entries := make([]bufferedLogEntry, 0)
 
 	// Register cleanup function to output buffered logs if test failed
 	t.Cleanup(func() {
-		if t.Failed() && len(wrapped.entries) > 0 {
+		if t.Failed() && len(entries) > 0 {
 			var buffer strings.Builder
 			var size int
-			for _, entry := range wrapped.entries {
+			for _, entry := range entries {
 				size += 9 + len(entry.file) + len(entry.message)
 			}
 			buffer.Grow(size)
 			_, _ = buffer.Write([]byte("=== Buffered Log Output (test failed) ===\n"))
-			for _, entry := range wrapped.entries {
+			for _, entry := range entries {
 				_, _ = fmt.Fprintf(&buffer, "%s:%d %s\n", entry.file, entry.line, entry.message)
 			}
 			_, _ = buffer.Write([]byte("=== End Buffered Log Output ===\n"))
 			t.Log(buffer.String())
 		} else {
-			t.Logf("dropping %d log entries (test passed)", len(wrapped.entries))
+			t.Logf("dropping %d log entries (test passed)", len(entries))
 		}
 	})
 
-	return wrapped
-}
-
-// BufferedLogger creates a T that buffers all log output and supports RunT functionality.
-func BufferedLogger[ET T](t ET) RunT[T] {
-	if os.Getenv("NTEST_BUFFERING") == "false" {
-		// When buffering is disabled, return the original T wrapped only for matrix testing
-		// This avoids any extra stack frames from the buffering wrapper
-		if runT, ok := any(t).(RunT[ET]); ok {
-			return NewTestRunner(runT)
-		}
-		// If t is not already a RunT, we need to create a minimal wrapper
-		// This should rarely happen in practice since most T's passed here implement RunT
-		simple := simpleRunT[ET]{
-			runTHelper: runTHelper{T: t},
-			orig:       t,
-		}
-		return NewTestRunner[ET](simple)
-	}
-
-	buffered := BufferedLoggerT(t)
-	return tRunWrapper[*BufferedLogWrappedT[ET]]{
-		T:     buffered, // Use buffered, not original t
-		inner: buffered,
-	}
-}
-
-func (t *BufferedLogWrappedT[ET]) addLogEntry(message string) {
-	// Get caller information (skip 2 frames + additional skipFrames: this function and the Log/Logf wrapper + any additional)
-	pc, file, line, ok := runtime.Caller(2 + t.skipFrames)
-	if !ok {
-		file = "unknown"
-		line = 0
-	} else {
-		// Get just the filename, not the full path
-		if idx := strings.LastIndex(file, "/"); idx >= 0 {
-			file = file[idx+1:]
-		}
-	}
-
-	var function string
-	if pc != 0 {
-		if fn := runtime.FuncForPC(pc); fn != nil {
-			function = fn.Name()
-			// Strip package path from function name
-			if idx := strings.LastIndex(function, "."); idx >= 0 {
-				function = function[idx+1:]
+	return func(message string) {
+		// Get caller information
+		// Stack: runtime.Caller <- this lambda <- LoggerT.Log/Logf <- user code
+		// We need to skip: this function (1) + LoggerT.Log/Logf (1) + any additional frames (skipFrames)
+		pc, file, line, ok := runtime.Caller(2 + skipFrames)
+		if !ok {
+			file = "unknown"
+			line = 0
+		} else {
+			// Get just the filename, not the full path
+			if idx := strings.LastIndex(file, "/"); idx >= 0 {
+				file = file[idx+1:]
 			}
 		}
-	}
 
-	entry := bufferedLogEntry{
-		message:  message,
-		file:     file,
-		line:     line,
-		function: function,
-	}
+		var function string
+		if pc != 0 {
+			if fn := runtime.FuncForPC(pc); fn != nil {
+				function = fn.Name()
+				// Strip package path from function name
+				if idx := strings.LastIndex(function, "."); idx >= 0 {
+					function = function[idx+1:]
+				}
+			}
+		}
 
-	t.entries = append(t.entries, entry)
+		entry := bufferedLogEntry{
+			message:  message,
+			file:     file,
+			line:     line,
+			function: function,
+		}
+
+		entries = append(entries, entry)
+	}
 }
 
-func (t *BufferedLogWrappedT[ET]) Log(args ...interface{}) {
-	line := fmt.Sprintln(args...)
-	message := line[0 : len(line)-1] // Remove trailing newline
-	t.addLogEntry(message)
-}
+// BufferedLogger creates a logger wrapper that buffers all log output and only
+// outputs it during test cleanup if the test failed. Each log entry
+// includes the filename and line number where the log was called.
+// The purpose of this is for situations where go tests are defaulting
+// to -v but output should be suppressed anyway.
+//
+// If the environment variable NTEST_BUFFERING is set to "false", buffering
+// will be turned off.
+// Returns RunT[LoggerT] for consistency with other logger wrappers.
+func BufferedLogger[ET T](t ET) RunT[LoggerT[ET]] {
+	logger := createBufferedLogger(t, 0)
 
-func (t *BufferedLogWrappedT[ET]) Logf(format string, args ...interface{}) {
-	message := fmt.Sprintf(format, args...)
-	t.addLogEntry(message)
+	wrapped := LoggerT[ET]{
+		runTHelper: runTHelper{T: t}, // Set the embedded helper
+		orig:       t,                // Keep reference to original
+		logger:     logger,
+	}
+
+	return wrapped // LoggerT[ET] implements RunT[LoggerT[ET]]
 }

--- a/logger.go
+++ b/logger.go
@@ -68,8 +68,8 @@ func (t replaceLoggerT[ET]) Run(name string, f func(*testing.T)) bool {
 	return false
 }
 
-// ReWrap implements ReWrapper to recreate replaceLoggerT with fresh *testing.T
-func (t replaceLoggerT[ET]) ReWrap(newT *testing.T) T {
+// ReWrap implements ReWrapper to recreate replaceLoggerT with fresh T
+func (t replaceLoggerT[ET]) ReWrap(newT T) T {
 	if reWrapper, ok := any(t.T).(ReWrapper); ok {
 		rewrapped := reWrapper.ReWrap(newT)
 		return ReplaceLogger(rewrapped, t.logger)
@@ -84,8 +84,8 @@ func (t *replaceLoggerT[ET]) AdjustSkipFrames(skip int) {
 	}
 }
 
-// ReWrap implements ReWrapper to recreate loggerT with fresh *testing.T
-func (t loggerT[ET]) ReWrap(newT *testing.T) T {
+// ReWrap implements ReWrapper to recreate loggerT with fresh T
+func (t loggerT[ET]) ReWrap(newT T) T {
 	// Delegate to the embedded replaceLoggerT's ReWrap to handle chaining properly
 	reWrappedBase := t.replaceLoggerT.ReWrap(newT)
 
@@ -224,8 +224,8 @@ func AsRunT[ET T](t ET) RunT {
 	return NewTestRunner(t)
 }
 
-// ReWrapper allows types that wrap T to recreate themselves from fresh *testing.T
+// ReWrapper allows types that wrap T to recreate themselves from fresh T
 // This enables proper sub-test handling in matrix testing while preserving wrapper behavior
 type ReWrapper interface {
-	ReWrap(*testing.T) T
+	ReWrap(T) T
 }

--- a/logger.go
+++ b/logger.go
@@ -67,6 +67,7 @@ func (t replaceLoggerT[ET]) Run(name string, f func(*testing.T)) bool {
 		return runnable.Run(name, f)
 	}
 	t.T.Logf("Run not supported by %T", t.orig)
+	//nolint:staticcheck // QF1008: could remove embedded field "T" from selector
 	t.T.FailNow()
 	return false
 }
@@ -114,6 +115,7 @@ func (t loggerT[ET]) Run(name string, f func(*testing.T)) bool {
 		return runnable.Run(name, f)
 	}
 	t.T.Logf("Run not supported by %T", t.orig)
+	//nolint:staticcheck // QF1008: could remove embedded field "T" from selector
 	t.T.FailNow()
 	return false
 }

--- a/logger.go
+++ b/logger.go
@@ -78,7 +78,8 @@ func (t replaceLoggerT[ET]) ReWrap(newT T) T {
 	return ReplaceLogger(newT, t.logger)
 }
 
-// AdjustSkipFrames forwards to the underlying logger if it supports it
+// AdjustSkipFrames forwards to the underlying logger if it supports it. This
+// is a delta not an absolute.
 func (t *replaceLoggerT[ET]) AdjustSkipFrames(skip int) {
 	if adjuster, ok := any(t.T).(interface{ AdjustSkipFrames(int) }); ok {
 		adjuster.AdjustSkipFrames(skip)

--- a/logger.go
+++ b/logger.go
@@ -171,6 +171,10 @@ func createBufferedLoggerWithDynamicSkip[ET T](t ET, skipFramesFunc func() int) 
 //
 // If the environment variable NTEST_BUFFERING is set to "false", buffering
 // will be turned off and the original T will be returned directly.
+//
+// One advantage of using BufferedLogger over using "go test" (without -v) is
+// that you can see the skipped tests with BufferedLogger whereas non-v go test
+// hides the skips.
 func BufferedLogger[ET T](t ET) T {
 	if os.Getenv("NTEST_BUFFERING") == "false" {
 		// When buffering is disabled, return the original T directly to avoid any intermediate calls

--- a/logger.go
+++ b/logger.go
@@ -22,12 +22,12 @@ type replaceLoggerT[ET T] struct {
 }
 
 // ReplaceLogger creates a wrapped T that overrides the logging function. When layered
-// on top of BufferedLogger (which cares about stack frames), it assumes that one extra
-// extra stack frame is added by the logger function.
-// If that's not the case, cast and adjust:
+// on top of BufferedLogger (which cares about stack frames), it automatically adjusts
+// for the extra stack frames: replaceLoggerT.Log -> user logger function -> underlying logger.
+// If the user logger function adds additional frames beyond the expected one, cast and adjust:
 //
 //	if asf, ok := t.(interface{ AdjustSkipFrames(int) }); ok {
-//		asf.AdjustSkipFrames(2)
+//		asf.AdjustSkipFrames(1) // +1 more beyond the default adjustment
 //	}
 //
 // This adjustment should be done before using the the returned T

--- a/logger.go
+++ b/logger.go
@@ -56,15 +56,16 @@ func (t replaceLoggerT[ET]) Logf(format string, args ...interface{}) {
 }
 
 // Run implements the new RunT interface
+// Note: This passes the raw *testing.T to the function, losing logger wrapping.
+// Use RunWithReWrap instead if you need to preserve logger wrapping in subtests.
 func (t replaceLoggerT[ET]) Run(name string, f func(*testing.T)) bool {
-	if runnable, ok := any(t.T).(interface {
-		Run(string, func(*testing.T)) bool
-	}); ok {
+	if runnable, ok := any(t.T).(RunT); ok {
 		return runnable.Run(name, f)
 	}
+	//nolint:staticcheck // QF1008: could remove embedded field "T" from selector
 	t.T.Logf("Run not supported by %T", t.T)
 	//nolint:staticcheck // QF1008: could remove embedded field "T" from selector
-	t.T.FailNow()
+	t.T.Fail()
 	return false
 }
 

--- a/logger.go
+++ b/logger.go
@@ -8,48 +8,76 @@ import (
 	"time"
 )
 
-type logWrappedT struct {
-	T
+type logWrappedT[ET T] struct {
+	eitherT[logWrappedT[ET], ET]
 	logger func(string)
 }
 
 // ReplaceLogger creates a T that is wrapped so that the logger is
 // overridden with the provided function.
-func ReplaceLogger(t T, logger func(string)) T {
-	return logWrappedT{
-		T:      t,
+func ReplaceLogger[ET T](t ET, logger func(string)) T {
+	self := logWrappedT[ET]{
 		logger: logger,
 	}
+	self.eitherT = makeEitherTSimple[ET](t, self)
+	return self
 }
 
-func (t logWrappedT) Log(args ...interface{}) {
+func (t logWrappedT[ET]) Log(args ...interface{}) {
 	line := fmt.Sprintln(args...)
 	t.logger(line[0 : len(line)-1])
 }
 
-func (t logWrappedT) Logf(format string, args ...interface{}) {
+func (t logWrappedT[ET]) Logf(format string, args ...interface{}) {
 	t.logger(fmt.Sprintf(format, args...))
 }
 
 // AdjustSkipFrames adjusts skip frames on the underlying T if it supports it
-func (t logWrappedT) AdjustSkipFrames(skip int) {
-	if adjuster, ok := t.T.(interface{ AdjustSkipFrames(int) }); ok {
+func (t logWrappedT[ET]) AdjustSkipFrames(skip int) {
+	if adjuster, ok := any(t.eitherT).(interface{ AdjustSkipFrames(int) }); ok {
 		adjuster.AdjustSkipFrames(skip)
 	}
 }
 
-// ExtraDetailLogger creates a T that wraps the logger to add both a
+// ExtraDetailLogger creates a logger wrapper that adds both a
 // prefix and a timestamp to each line that is logged.
-func ExtraDetailLogger(t T, prefix string) T {
+// Returns logWrappedT which implements RunT for use with matrix testing.
+func ExtraDetailLogger[ET T](t ET, prefix string) logWrappedT[ET] {
 	// First, adjust skip frames on the underlying T if it supports it
 	// We need to skip 2 additional frames: the lambda function and the ReplaceLogger wrapper
-	if adjuster, ok := t.(interface{ AdjustSkipFrames(int) }); ok {
-		adjuster.AdjustSkipFrames(2)
+	skipFrames := 2
+
+	// Check if the underlying T is a tRunWrapper by checking if it has the specific method signature
+	// This is a bit of a hack, but it works to detect tRunWrapper without generics issues
+	tValue := any(t)
+	if wrapper, ok := tValue.(interface {
+		Run(string, func(T)) bool
+	}); ok {
+		// This looks like a tRunWrapper, so we need one more skip frame for tRunWrapper.Log
+		_ = wrapper // avoid unused variable
+		skipFrames = 3
 	}
 
-	wrapped := ReplaceLogger(t, func(s string) {
+	if adjuster, ok := any(t).(interface{ AdjustSkipFrames(int) }); ok {
+		adjuster.AdjustSkipFrames(skipFrames)
+	}
+
+	logger := func(s string) {
 		t.Log(prefix, time.Now().Format("15:04:05"), s)
-	})
+	}
+
+	// Create a constructor function that captures the logger
+	makeLogWrapped := func(either eitherT[logWrappedT[ET], ET]) logWrappedT[ET] {
+		return logWrappedT[ET]{
+			eitherT: either,
+			logger:  logger,
+		}
+	}
+
+	wrapped := logWrappedT[ET]{
+		eitherT: makeEitherT[logWrappedT[ET], ET](t, makeLogWrapped),
+		logger:  logger,
+	}
 
 	return wrapped
 }
@@ -61,14 +89,15 @@ type bufferedLogEntry struct {
 	function string
 }
 
-type bufferedLogWrappedT struct {
-	T
+// BufferedLogWrappedT is the type returned by BufferedLogger
+type BufferedLogWrappedT[ET T] struct {
+	eitherT[*BufferedLogWrappedT[ET], ET]
 	entries    []bufferedLogEntry
 	skipFrames int // Number of additional stack frames to skip
 }
 
 // AdjustSkipFrames changes the number of stack frames to skip when capturing caller info
-func (t *bufferedLogWrappedT) AdjustSkipFrames(skip int) {
+func (t *BufferedLogWrappedT[ET]) AdjustSkipFrames(skip int) {
 	t.skipFrames = skip
 }
 
@@ -80,12 +109,30 @@ func (t *bufferedLogWrappedT) AdjustSkipFrames(skip int) {
 //
 // If the environment variable NTEST_BUFFERING is set to "false", buffering
 // will be turned off.
-func BufferedLogger(t T) T {
+// BufferedLoggerT returns a BufferedLogger that implements RunT for matrix testing
+func BufferedLoggerT[ET T](t ET) *BufferedLogWrappedT[ET] {
 	if os.Getenv("NTEST_BUFFERING") == "false" {
-		return t
+		// When buffering is disabled, we still need to return the wrapper type
+		// but we'll make it pass through to the underlying T with proper stack frame handling
+		wrapped := &BufferedLogWrappedT[ET]{
+			entries:    make([]bufferedLogEntry, 0),
+			skipFrames: 2, // Account for the wrapper stack frames
+		}
+		wrapped.eitherT = makeEitherTSimple[ET](t, wrapped)
+		return wrapped
 	}
-	wrapped := &bufferedLogWrappedT{
-		T:          t,
+
+	// Create a constructor function for the buffered wrapper
+	makeBufferedWrapped := func(either eitherT[*BufferedLogWrappedT[ET], ET]) *BufferedLogWrappedT[ET] {
+		return &BufferedLogWrappedT[ET]{
+			eitherT:    either,
+			entries:    make([]bufferedLogEntry, 0),
+			skipFrames: 0,
+		}
+	}
+
+	wrapped := &BufferedLogWrappedT[ET]{
+		eitherT:    makeEitherT[*BufferedLogWrappedT[ET], ET](t, makeBufferedWrapped),
 		entries:    make([]bufferedLogEntry, 0),
 		skipFrames: 0,
 	}
@@ -113,7 +160,16 @@ func BufferedLogger(t T) T {
 	return wrapped
 }
 
-func (t *bufferedLogWrappedT) addLogEntry(message string) {
+// BufferedLogger creates a T that buffers all log output and supports RunT functionality.
+func BufferedLogger[ET T](t ET) RunT[T] {
+	buffered := BufferedLoggerT(t)
+	// When wrapping with tRunWrapper, we need to skip one additional frame
+	// because tRunWrapper.Log() adds another level to the call stack
+	buffered.AdjustSkipFrames(1)
+	return tRunWrapper[*BufferedLogWrappedT[ET]]{inner: buffered}
+}
+
+func (t *BufferedLogWrappedT[ET]) addLogEntry(message string) {
 	// Get caller information (skip 2 frames + additional skipFrames: this function and the Log/Logf wrapper + any additional)
 	pc, file, line, ok := runtime.Caller(2 + t.skipFrames)
 	if !ok {
@@ -147,13 +203,13 @@ func (t *bufferedLogWrappedT) addLogEntry(message string) {
 	t.entries = append(t.entries, entry)
 }
 
-func (t *bufferedLogWrappedT) Log(args ...interface{}) {
+func (t *BufferedLogWrappedT[ET]) Log(args ...interface{}) {
 	line := fmt.Sprintln(args...)
 	message := line[0 : len(line)-1] // Remove trailing newline
 	t.addLogEntry(message)
 }
 
-func (t *bufferedLogWrappedT) Logf(format string, args ...interface{}) {
+func (t *BufferedLogWrappedT[ET]) Logf(format string, args ...interface{}) {
 	message := fmt.Sprintf(format, args...)
 	t.addLogEntry(message)
 }

--- a/logger.go
+++ b/logger.go
@@ -11,7 +11,7 @@ import (
 )
 
 type loggerT[ET T] struct {
-	runTHelper    // Embeds T and provides Fail/Parallel
+	T             // Direct embedding of T interface
 	orig       ET // Keep reference to original for Run method
 	logger     func(string)
 	skipFrames int // Additional skip frames for nested wrappers
@@ -19,7 +19,7 @@ type loggerT[ET T] struct {
 
 // replaceLoggerT directly implements T interface to avoid double loggerT wrapping
 type replaceLoggerT[ET T] struct {
-	runTHelper
+	T      // Direct embedding of T interface
 	orig   ET
 	logger func(string)
 }
@@ -41,9 +41,9 @@ func ReplaceLogger[ET T](t ET, logger func(string)) T {
 	}
 
 	wrapped := &replaceLoggerT[ET]{
-		runTHelper: runTHelper{T: t},
-		orig:       t,
-		logger:     logger,
+		T:      t,
+		orig:   t,
+		logger: logger,
 	}
 	return any(wrapped).(T)
 }
@@ -129,7 +129,7 @@ func (t loggerT[ET]) ReWrap(newT *testing.T) T {
 
 	// Create new loggerT with the same logger function but fresh underlying
 	wrapped := &loggerT[*testing.T]{
-		runTHelper: runTHelper{T: newT},
+		T:          newT,
 		orig:       newT,
 		logger:     t.logger, // Reuse the same logger function
 		skipFrames: t.skipFrames,
@@ -234,9 +234,9 @@ func BufferedLogger[ET T](t ET) T {
 	}
 
 	wrapped := &loggerT[ET]{
-		runTHelper: runTHelper{T: t}, // Set the embedded helper
-		orig:       t,                // Keep reference to original
-		skipFrames: 0,                // Initialize skip frames, will be adjusted by AdjustSkipFrames
+		T:          t, // Direct embedding of T interface
+		orig:       t, // Keep reference to original
+		skipFrames: 0, // Initialize skip frames, will be adjusted by AdjustSkipFrames
 	}
 
 	// Create the logger function that uses the current skipFrames from wrapped

--- a/logger.go
+++ b/logger.go
@@ -112,7 +112,7 @@ func createBufferedLoggerWithDynamicSkip[ET T](t ET, skipFramesFunc func() int) 
 		lock.Lock()
 		defer lock.Unlock()
 		cleanupCalled = true
-		if t.Failed() && len(entries) > 0 {
+		if (t.Failed() || t.Skipped()) && len(entries) > 0 {
 			var buffer strings.Builder
 			var size int
 			for _, entry := range entries {

--- a/logger.go
+++ b/logger.go
@@ -21,9 +21,10 @@ type replaceLoggerT[ET T] struct {
 	logger func(string)
 }
 
-// ReplaceLogger creates a logger wrapper that overrides the logging function. When layered
-// on top of BufferedLogger, it assumes that only one extra stack frame is added. If that's
-// not the case, cast and adjust:
+// ReplaceLogger creates a wrapped T that overrides the logging function. When layered
+// on top of BufferedLogger (which cares about stack frames), it assumes that one extra
+// extra stack frame is added by the logger function.
+// If that's not the case, cast and adjust:
 //
 //	if asf, ok := t.(interface{ AdjustSkipFrames(int) }); ok {
 //		asf.AdjustSkipFrames(2)
@@ -109,8 +110,7 @@ func (t *loggerT[ET]) AdjustSkipFrames(skip int) {
 // the prefix is also added.
 func ExtraDetailLogger[ET T](t ET, prefix string) T {
 	return ReplaceLogger(t, func(s string) {
-		prefixedMessage := fmt.Sprintf("%s %s %s", prefix, time.Now().Format("15:04:05"), s)
-		t.Log(prefixedMessage)
+		t.Logf("%s %s %s", prefix, time.Now().Format("15:04:05"), s)
 	})
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -305,6 +305,14 @@ func (m *mockedT) triggerCleanup() {
 	}
 }
 
+func (m *mockedT) Fail() {
+	m.failed = true
+}
+
+func (m *mockedT) Parallel() {
+	// No-op for mock - parallel execution not relevant for mock
+}
+
 func (m *mockedT) setFailed() {
 	m.failed = true
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -112,12 +112,14 @@ func testLineNumberAccuracy(t *testing.T, logger ntest.T, mockT *mockedT, expect
 	expectedLine := strconv.Itoa(logLine)
 
 	t.Logf("Looking for line number: %s", expectedLine)
-	for _, log := range mockT.captured {
-		t.Logf("examining: %s", log)
-		if strings.Contains(log, "Test message for line accuracy") && strings.Contains(log, "logger_test.go:"+expectedLine) && strings.Contains(log, "Test message for line accuracy") {
-			found = true
-			t.Logf("✓ Found log message with correct line number: %s", log)
-			break
+	for _, entry := range mockT.captured {
+		for _, log := range strings.Split(entry, "\n") {
+			t.Logf("examining: %s", log)
+			if strings.Contains(log, "Test message for line accuracy") && strings.Contains(log, "logger_test.go:"+expectedLine) && strings.Contains(log, "Test message for line accuracy") && !strings.Contains(log, "logger.go:") {
+				found = true
+				t.Logf("✓ Found log message with correct line number: %s", log)
+				break
+			}
 		}
 	}
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -59,6 +59,8 @@ func TestExtraDetailLogger_WithBufferedLogger_LineNumberAccuracy(t *testing.T) {
 	testLineNumberAccuracy(t, extraDetail, mockT, true, true) // expect buffering, test should fail to check line numbers
 }
 
+// TODO: test ReplaceLogger directly
+
 func TestExtraDetailLogger_WithBufferedLogger_NoBuffering_LineNumberAccuracy(t *testing.T) {
 	// Set environment variable to disable buffering
 	t.Setenv("NTEST_BUFFERING", "false")

--- a/logger_test.go
+++ b/logger_test.go
@@ -75,15 +75,6 @@ func TestBufferedLogger_LineNumberAccuracy(t *testing.T) {
 	testLineNumberAccuracy(t, buffered, mockT, true, true) // expect buffering, test should fail to check line numbers
 }
 
-func TestBufferedLogger_LineNumberAccuracy_AsRunT(t *testing.T) {
-	if _, ok := os.LookupEnv("NTEST_BUFFERING"); ok {
-		t.Setenv("NTEST_BUFFERING", "true")
-	}
-	mockT := newMockedT(t)
-	buffered := ntest.BufferedLogger(mockT)
-	testLineNumberAccuracy(t, ntest.AsRunT(buffered), mockT, true, true) // expect buffering, test should fail to check line numbers
-}
-
 func TestExtraDetailLogger_WithBufferedLogger_LineNumberAccuracy(t *testing.T) {
 	if _, ok := os.LookupEnv("NTEST_BUFFERING"); ok {
 		t.Setenv("NTEST_BUFFERING", "true")
@@ -92,16 +83,6 @@ func TestExtraDetailLogger_WithBufferedLogger_LineNumberAccuracy(t *testing.T) {
 	buffered := ntest.BufferedLogger(mockT)
 	extraDetail := ntest.ExtraDetailLogger(buffered, "PREFIX")
 	testLineNumberAccuracy(t, extraDetail, mockT, true, true, "PREFIX") // expect buffering, test should fail to check line numbers
-}
-
-func TestExtraDetailLogger_WithBufferedLogger_LineNumberAccuracy_AsRunT(t *testing.T) {
-	if _, ok := os.LookupEnv("NTEST_BUFFERING"); ok {
-		t.Setenv("NTEST_BUFFERING", "true")
-	}
-	mockT := newMockedT(t)
-	buffered := ntest.BufferedLogger(mockT)
-	extraDetail := ntest.ExtraDetailLogger(buffered, "PREFIX")
-	testLineNumberAccuracy(t, ntest.AsRunT(extraDetail), mockT, true, true, "PREFIX") // expect buffering, test should fail to check line numbers
 }
 
 func TestExtraDetailLogger_Doubled_WithBufferedLogger_LineNumberAccuracy(t *testing.T) {
@@ -113,17 +94,6 @@ func TestExtraDetailLogger_Doubled_WithBufferedLogger_LineNumberAccuracy(t *test
 	extraDetail := ntest.ExtraDetailLogger(buffered, "PREFIX1")
 	extraDetail2 := ntest.ExtraDetailLogger(extraDetail, "PREFIX2")
 	testLineNumberAccuracy(t, extraDetail2, mockT, true, true, "PREFIX2", "PREFIX1") // expect buffering, test should fail to check line numbers
-}
-
-func TestExtraDetailLogger_Doubled_WithBufferedLogger_LineNumberAccuracy_AsRunT(t *testing.T) {
-	if _, ok := os.LookupEnv("NTEST_BUFFERING"); ok {
-		t.Setenv("NTEST_BUFFERING", "true")
-	}
-	mockT := newMockedT(t)
-	buffered := ntest.BufferedLogger(mockT)
-	extraDetail := ntest.ExtraDetailLogger(buffered, "PREFIX1")
-	extraDetail2 := ntest.ExtraDetailLogger(extraDetail, "PREFIX2")
-	testLineNumberAccuracy(t, ntest.AsRunT(extraDetail2), mockT, true, true, "PREFIX2", "PREFIX1") // expect buffering, test should fail to check line numbers
 }
 
 func TestReplaceLogger_WithBufferedLogger_LineNumberAccuracy(t *testing.T) {
@@ -170,25 +140,13 @@ func TestExtraDetailInsideRun(t *testing.T) {
 		buffered.Log(s + " SUFFIX")
 	})
 	var ran bool
-	success := ntest.RunWithReWrap(ntest.AsRunT(extraDetail), "inner", func(wrapped ntest.RunT) {
+	success := ntest.RunWithReWrap(extraDetail, "inner", func(wrapped ntest.T) {
 		inner := mockT.getInner(wrapped.Name())
 		testLineNumberAccuracy(inner.real, wrapped, mockT, true, true, "SUFFIX") // expect buffering, test should fail to check line numbers
 		ran = true
 	})
 	require.True(t, success)
 	require.True(t, ran)
-}
-
-func TestReplaceLogger_WithBufferedLogger_LineNumberAccuracy_AsRunT(t *testing.T) {
-	if _, ok := os.LookupEnv("NTEST_BUFFERING"); ok {
-		t.Setenv("NTEST_BUFFERING", "true")
-	}
-	mockT := newMockedT(t)
-	buffered := ntest.BufferedLogger(mockT)
-	extraDetail := ntest.ReplaceLogger(buffered, func(s string) {
-		buffered.Log(s + " SUFFIX")
-	})
-	testLineNumberAccuracy(t, ntest.AsRunT(extraDetail), mockT, true, true, "SUFFIX") // expect buffering, test should fail to check line numbers
 }
 
 func TestExtraDetailLogger_WithBufferedLogger_NoBuffering_LineNumberAccuracy(t *testing.T) {
@@ -198,15 +156,6 @@ func TestExtraDetailLogger_WithBufferedLogger_NoBuffering_LineNumberAccuracy(t *
 	mockT := newMockedT(t)
 	buffered := ntest.BufferedLogger(mockT)
 	testLineNumberAccuracy(t, buffered, mockT, false, false) // no buffering, test passes (logs appear immediately)
-}
-
-func TestExtraDetailLogger_WithBufferedLogger_NoBuffering_LineNumberAccuracy_AsRunT(t *testing.T) {
-	// Set environment variable to disable buffering
-	t.Setenv("NTEST_BUFFERING", "false")
-
-	mockT := newMockedT(t)
-	buffered := ntest.BufferedLogger(mockT)
-	testLineNumberAccuracy(t, ntest.AsRunT(buffered), mockT, false, false) // no buffering, test passes (logs appear immediately)
 }
 
 // Generic line number accuracy test that works with different logger configurations

--- a/logger_test.go
+++ b/logger_test.go
@@ -49,7 +49,7 @@ func TestPrefixLogger(t *testing.T) {
 func TestBufferedLogger_LineNumberAccuracy(t *testing.T) {
 	mockT := newMockedT("TestBufferedLogger_LineNumberAccuracy")
 	buffered := ntest.BufferedLogger(mockT)
-	testLineNumberAccuracy(t, buffered, mockT, true, true, "") // expect buffering, test should fail to check line numbers
+	testLineNumberAccuracy(t, buffered, mockT, true, true) // expect buffering, test should fail to check line numbers
 }
 
 func TestExtraDetailLogger_WithBufferedLogger_LineNumberAccuracy(t *testing.T) {
@@ -57,6 +57,14 @@ func TestExtraDetailLogger_WithBufferedLogger_LineNumberAccuracy(t *testing.T) {
 	buffered := ntest.BufferedLogger(mockT)
 	extraDetail := ntest.ExtraDetailLogger(buffered, "PREFIX")
 	testLineNumberAccuracy(t, extraDetail, mockT, true, true, "PREFIX") // expect buffering, test should fail to check line numbers
+}
+
+func TestExtraDetailLogger_Doubled_WithBufferedLogger_LineNumberAccuracy(t *testing.T) {
+	mockT := newMockedT("TestExtraDetailLogger_LineNumberAccuracy")
+	buffered := ntest.BufferedLogger(mockT)
+	extraDetail := ntest.ExtraDetailLogger(buffered, "PREFIX")
+	extraDetail2 := ntest.ExtraDetailLogger(extraDetail, "PREFIX2")
+	testLineNumberAccuracy(t, extraDetail2, mockT, true, true, "PREFIX2", "PREFIX") // expect buffering, test should fail to check line numbers
 }
 
 func TestReplaceLogger_WithBufferedLogger_LineNumberAccuracy(t *testing.T) {
@@ -74,11 +82,11 @@ func TestExtraDetailLogger_WithBufferedLogger_NoBuffering_LineNumberAccuracy(t *
 
 	mockT := newMockedT("TestExtraDetailLogger_NoBuffering")
 	buffered := ntest.BufferedLogger(mockT)
-	testLineNumberAccuracy(t, buffered, mockT, false, false, "") // no buffering, test passes (logs appear immediately)
+	testLineNumberAccuracy(t, buffered, mockT, false, false) // no buffering, test passes (logs appear immediately)
 }
 
 // Generic line number accuracy test that works with different logger configurations
-func testLineNumberAccuracy(t *testing.T, logger ntest.T, mockT *mockedT, expectBuffering bool, shouldFail bool, mustFind string) {
+func testLineNumberAccuracy(t *testing.T, logger ntest.T, mockT *mockedT, expectBuffering bool, shouldFail bool, mustFind ...string) {
 	if expectBuffering {
 		if shouldFail {
 			t.Log("Testing buffered logger with failing test (should output buffered logs)")
@@ -124,8 +132,8 @@ func testLineNumberAccuracy(t *testing.T, logger ntest.T, mockT *mockedT, expect
 	for _, entry := range mockT.captured {
 		for _, log := range strings.Split(entry, "\n") {
 			t.Logf("examining: %s", log)
-			if mustFind != "" {
-				if !strings.Contains(log, mustFind) {
+			for _, s := range mustFind {
+				if !strings.Contains(log, s) {
 					continue
 				}
 			}

--- a/logger_test.go
+++ b/logger_test.go
@@ -52,11 +52,24 @@ func TestBufferedLogger_LineNumberAccuracy(t *testing.T) {
 	testLineNumberAccuracy(t, buffered, mockT, true, true) // expect buffering, test should fail to check line numbers
 }
 
+func TestBufferedLogger_LineNumberAccuracy_AsRunT(t *testing.T) {
+	mockT := newMockedT("TestBufferedLogger_LineNumberAccuracy")
+	buffered := ntest.BufferedLogger(mockT)
+	testLineNumberAccuracy(t, ntest.AsRunT(buffered), mockT, true, true) // expect buffering, test should fail to check line numbers
+}
+
 func TestExtraDetailLogger_WithBufferedLogger_LineNumberAccuracy(t *testing.T) {
 	mockT := newMockedT("TestExtraDetailLogger_LineNumberAccuracy")
 	buffered := ntest.BufferedLogger(mockT)
 	extraDetail := ntest.ExtraDetailLogger(buffered, "PREFIX")
 	testLineNumberAccuracy(t, extraDetail, mockT, true, true, "PREFIX") // expect buffering, test should fail to check line numbers
+}
+
+func TestExtraDetailLogger_WithBufferedLogger_LineNumberAccuracy_AsRunT(t *testing.T) {
+	mockT := newMockedT("TestExtraDetailLogger_LineNumberAccuracy")
+	buffered := ntest.BufferedLogger(mockT)
+	extraDetail := ntest.ExtraDetailLogger(buffered, "PREFIX")
+	testLineNumberAccuracy(t, ntest.AsRunT(extraDetail), mockT, true, true, "PREFIX") // expect buffering, test should fail to check line numbers
 }
 
 func TestExtraDetailLogger_Doubled_WithBufferedLogger_LineNumberAccuracy(t *testing.T) {
@@ -65,6 +78,14 @@ func TestExtraDetailLogger_Doubled_WithBufferedLogger_LineNumberAccuracy(t *test
 	extraDetail := ntest.ExtraDetailLogger(buffered, "PREFIX")
 	extraDetail2 := ntest.ExtraDetailLogger(extraDetail, "PREFIX2")
 	testLineNumberAccuracy(t, extraDetail2, mockT, true, true, "PREFIX2", "PREFIX") // expect buffering, test should fail to check line numbers
+}
+
+func TestExtraDetailLogger_Doubled_WithBufferedLogger_LineNumberAccuracy_AsRunT(t *testing.T) {
+	mockT := newMockedT("TestExtraDetailLogger_LineNumberAccuracy")
+	buffered := ntest.BufferedLogger(mockT)
+	extraDetail := ntest.ExtraDetailLogger(buffered, "PREFIX")
+	extraDetail2 := ntest.ExtraDetailLogger(extraDetail, "PREFIX2")
+	testLineNumberAccuracy(t, ntest.AsRunT(extraDetail2), mockT, true, true, "PREFIX2", "PREFIX") // expect buffering, test should fail to check line numbers
 }
 
 func TestReplaceLogger_WithBufferedLogger_LineNumberAccuracy(t *testing.T) {
@@ -76,6 +97,15 @@ func TestReplaceLogger_WithBufferedLogger_LineNumberAccuracy(t *testing.T) {
 	testLineNumberAccuracy(t, extraDetail, mockT, true, true, "SUFFIX") // expect buffering, test should fail to check line numbers
 }
 
+func TestReplaceLogger_WithBufferedLogger_LineNumberAccuracy_AsRunT(t *testing.T) {
+	mockT := newMockedT("TestExtraDetailLogger_LineNumberAccuracy")
+	buffered := ntest.BufferedLogger(mockT)
+	extraDetail := ntest.ReplaceLogger(buffered, func(s string) {
+		buffered.Log(s + " SUFFIX")
+	})
+	testLineNumberAccuracy(t, ntest.AsRunT(extraDetail), mockT, true, true, "SUFFIX") // expect buffering, test should fail to check line numbers
+}
+
 func TestExtraDetailLogger_WithBufferedLogger_NoBuffering_LineNumberAccuracy(t *testing.T) {
 	// Set environment variable to disable buffering
 	t.Setenv("NTEST_BUFFERING", "false")
@@ -83,6 +113,15 @@ func TestExtraDetailLogger_WithBufferedLogger_NoBuffering_LineNumberAccuracy(t *
 	mockT := newMockedT("TestExtraDetailLogger_NoBuffering")
 	buffered := ntest.BufferedLogger(mockT)
 	testLineNumberAccuracy(t, buffered, mockT, false, false) // no buffering, test passes (logs appear immediately)
+}
+
+func TestExtraDetailLogger_WithBufferedLogger_NoBuffering_LineNumberAccuracy_AsRunT(t *testing.T) {
+	// Set environment variable to disable buffering
+	t.Setenv("NTEST_BUFFERING", "false")
+
+	mockT := newMockedT("TestExtraDetailLogger_NoBuffering")
+	buffered := ntest.BufferedLogger(mockT)
+	testLineNumberAccuracy(t, ntest.AsRunT(buffered), mockT, false, false) // no buffering, test passes (logs appear immediately)
 }
 
 // Generic line number accuracy test that works with different logger configurations

--- a/logger_test.go
+++ b/logger_test.go
@@ -45,6 +45,24 @@ func TestPrefixLogger(t *testing.T) {
 	t.Log("ExtraDetailLogger test completed successfully")
 }
 
+// TestLoggerLogf tests the Logf method on loggerT
+func TestLoggerLogf(t *testing.T) {
+	t.Parallel()
+
+	var captured []string
+	captureLogger := ntest.ReplaceLogger(t, func(s string) {
+		captured = append(captured, s)
+	})
+
+	// Use BufferedLogger to create a loggerT instance, then call Logf
+	buffered := ntest.BufferedLogger(captureLogger)
+	buffered.Logf("Formatted message: %d %s", 42, "test")
+
+	// Since it's buffered and test will pass, we won't see the output directly
+	// But this ensures the Logf method is called
+	assert.NotNil(t, buffered, "BufferedLogger should return non-nil")
+}
+
 // Test line number accuracy for BufferedLogger
 func TestBufferedLogger_LineNumberAccuracy(t *testing.T) {
 	mockT := newMockedT("TestBufferedLogger_LineNumberAccuracy")

--- a/matrix.go
+++ b/matrix.go
@@ -75,8 +75,15 @@ func runMatrixTest(t RunT, parallel bool, chain []any) {
 }
 
 func breakChain(chain []any) (matrix map[string]nject.Provider, before []any, after []any) {
-	// Implementation for breaking the chain - this needs to be implemented
-	// For now, return a simple implementation
+	for i, item := range chain {
+		if m, ok := item.(map[string]nject.Provider); ok {
+			// Found the matrix, split the chain
+			before = chain[:i]
+			after = chain[i+1:]
+			return m, before, after
+		}
+	}
+	// No matrix found
 	return nil, chain, nil
 }
 

--- a/matrix.go
+++ b/matrix.go
@@ -45,7 +45,7 @@ func runMatrixTest(t RunT, parallel bool, chain []any) {
 	matrix, before, after := breakChain(chain)
 	if matrix == nil {
 		t.Log("FAIL: matrix test requires a matrix")
-		t.FailNow()
+		t.Fail()
 		return
 	}
 

--- a/matrix.go
+++ b/matrix.go
@@ -1,8 +1,6 @@
 package ntest
 
 import (
-	"testing"
-
 	"github.com/muir/nject/v2"
 )
 
@@ -21,7 +19,7 @@ import (
 //
 // Matrix values must be direct arguments to RunMatrix -- they will not be extracted
 // from nject.Sequences. RunParallelMatrix will fail if there is no matrix provided.
-func RunParallelMatrix(t *testing.T, chain ...any) {
+func RunParallelMatrix[GT RunT[GT]](t GT, chain ...any) {
 	t.Parallel()
 	runMatrixTest(t, true, chain)
 }
@@ -36,12 +34,12 @@ func RunParallelMatrix(t *testing.T, chain ...any) {
 //
 // Matrix values must be direct arguments to RunMatrix -- they will not be extracted
 // from nject.Sequences. RunMatrix will fail if there is no matrix provided.
-func RunMatrix(t *testing.T, chain ...any) {
+func RunMatrix[GT RunT[GT]](t GT, chain ...any) {
 	runMatrixTest(t, false, chain)
 }
 
-func runMatrixTest(t *testing.T, parallel bool, chain []any) {
-	breakChain := func(t *testing.T, chain []any) (matrix map[string]nject.Provider, before []any, after []any) {
+func runMatrixTest[GT RunT[GT]](t GT, parallel bool, chain []any) {
+	breakChain := func(t GT, chain []any) (matrix map[string]nject.Provider, before []any, after []any) {
 		for i, injector := range chain {
 			matrix, ok := injector.(map[string]nject.Provider)
 			if ok {
@@ -50,8 +48,8 @@ func runMatrixTest(t *testing.T, parallel bool, chain []any) {
 		}
 		return nil, nil, chain
 	}
-	testingT := func(t *testing.T) []any {
-		return []any{nject.Provide("testing.T", func() *testing.T { return t })}
+	testingT := func(t GT) []any {
+		return []any{nject.Provide("testing.T", func() GT { return t })}
 	}
 
 	matrix, before, after := breakChain(t, chain)
@@ -61,11 +59,11 @@ func runMatrixTest(t *testing.T, parallel bool, chain []any) {
 		return
 	}
 
-	var startTest func(t *testing.T, matrix map[string]nject.Provider, before []any, after []any)
-	startTest = func(t *testing.T, matrix map[string]nject.Provider, before []any, after []any) {
+	var startTest func(t GT, matrix map[string]nject.Provider, before []any, after []any)
+	startTest = func(t GT, matrix map[string]nject.Provider, before []any, after []any) {
 		for name, subChain := range matrix {
 			subChain := subChain
-			t.Run(name, func(t *testing.T) {
+			t.Run(name, func(t GT) {
 				if parallel {
 					t.Parallel()
 				}

--- a/matrix.go
+++ b/matrix.go
@@ -50,11 +50,13 @@ func runMatrixTest(t T, parallel bool, chain []any) {
 	if !ok {
 		t.Logf("Run not supported by %T", t)
 		t.Fail()
+		return
 	}
 	matrix, before, after := breakChain(chain)
 	if matrix == nil {
 		t.Log("FAIL: matrix test requires a matrix")
 		t.Fail()
+		return
 	}
 
 	var startTest func(T, map[string]nject.Provider, []any, []any)

--- a/matrix.go
+++ b/matrix.go
@@ -1,8 +1,6 @@
 package ntest
 
 import (
-	"testing"
-
 	"github.com/muir/nject/v2"
 )
 
@@ -50,15 +48,7 @@ func runMatrixTest(t RunT, parallel bool, chain []any) {
 	startTest = func(t RunT, matrix map[string]nject.Provider, before []any, after []any) {
 		for name, subChain := range matrix {
 			subChain := subChain
-			t.Run(name, func(subT *testing.T) {
-				// Implement ReWrapper logic here
-				var reWrapped RunT
-				if reWrapper, ok := t.(ReWrapper); ok {
-					reWrapped = NewTestRunner(reWrapper.ReWrap(subT))
-				} else {
-					reWrapped = NewTestRunner(subT)
-				}
-
+			RunWithReWrap(t, name, func(reWrapped RunT) {
 				if parallel {
 					reWrapped.Parallel()
 				}

--- a/t.go
+++ b/t.go
@@ -56,7 +56,9 @@ func (s simpleRunT) Run(name string, f func(*testing.T)) bool {
 	if runT, ok := s.orig.(RunT); ok {
 		return runT.Run(name, f)
 	}
+	//nolint:staticcheck // QF1008: could remove embedded field "T" from selector
 	s.T.Logf("Run not supported by %T", s.orig)
+	//nolint:staticcheck // QF1008: could remove embedded field "T" from selector
 	s.T.FailNow()
 	return false
 }
@@ -64,26 +66,6 @@ func (s simpleRunT) Run(name string, f func(*testing.T)) bool {
 func (s simpleRunT) Parallel() {
 	if parallel, ok := s.orig.(interface{ Parallel() }); ok {
 		parallel.Parallel()
-	}
-}
-
-// tRunWrapper wraps any RunT to implement RunT
-type tRunWrapper struct {
-	T
-	inner RunT
-}
-
-func (w tRunWrapper) Run(name string, f func(*testing.T)) bool {
-	return w.inner.Run(name, f)
-}
-
-func (w tRunWrapper) Parallel() { w.inner.Parallel() }
-
-// AdjustSkipFrames forwards the skip frame adjustment to the inner wrapper if it supports it
-// tRunWrapper adds 0 frames (it just delegates all T methods directly)
-func (w tRunWrapper) AdjustSkipFrames(skip int) {
-	if adjuster, ok := w.inner.(interface{ AdjustSkipFrames(int) }); ok {
-		adjuster.AdjustSkipFrames(skip) // +0 since tRunWrapper doesn't add any frames
 	}
 }
 
@@ -99,6 +81,7 @@ func (r runTHelper) Fail() {
 		return
 	}
 	// Fallback
+	//nolint:staticcheck // QF1008: could remove embedded field "T" from selector
 	r.T.FailNow()
 }
 

--- a/t.go
+++ b/t.go
@@ -59,7 +59,7 @@ func (s simpleRunT) Run(name string, f func(*testing.T)) bool {
 	//nolint:staticcheck // QF1008: could remove embedded field "T" from selector
 	s.T.Logf("Run not supported by %T", s.orig)
 	//nolint:staticcheck // QF1008: could remove embedded field "T" from selector
-	s.T.FailNow()
+	s.T.Fail()
 	return false
 }
 

--- a/t.go
+++ b/t.go
@@ -65,7 +65,8 @@ func (s simpleRunT) Run(name string, f func(*testing.T)) bool {
 
 // RunWithReWrap is a helper that runs a subtest and automatically handles ReWrap logic.
 // This should be used instead of calling t.Run in tests that use
-// ReplaceLogger, BufferedLogger, or ExtraDetailLogger.
+// ReplaceLogger, BufferedLogger, or ExtraDetailLogger. If running a test with a
+// wrapped logger that supports ReWrap, use RunWithReWrap.
 func RunWithReWrap(t RunT, name string, f func(RunT)) bool {
 	return t.Run(name, func(subT *testing.T) {
 		var reWrapped RunT
@@ -76,4 +77,10 @@ func RunWithReWrap(t RunT, name string, f func(RunT)) bool {
 		}
 		f(reWrapped)
 	})
+}
+
+// ReWrapper allows types that wrap T to recreate themselves from fresh T
+// This enables proper sub-test handling in matrix testing while preserving wrapper behavior
+type ReWrapper interface {
+	ReWrap(T) T
 }

--- a/t.go
+++ b/t.go
@@ -62,6 +62,7 @@ type Runner interface {
 
 // tRunWrapper wraps any RunT[WT] to implement RunT[T]
 type tRunWrapper[WT T] struct {
+	T
 	inner RunT[WT]
 }
 
@@ -71,28 +72,14 @@ func (w tRunWrapper[WT]) Run(name string, f func(T)) bool {
 	})
 }
 
-func (w tRunWrapper[WT]) Fail()                                     { w.inner.Fail() }
-func (w tRunWrapper[WT]) Parallel()                                 { w.inner.Parallel() }
-func (w tRunWrapper[WT]) Cleanup(f func())                          { w.inner.Cleanup(f) }
-func (w tRunWrapper[WT]) Setenv(key, value string)                  { w.inner.Setenv(key, value) }
-func (w tRunWrapper[WT]) Error(args ...interface{})                 { w.inner.Error(args...) }
-func (w tRunWrapper[WT]) Errorf(format string, args ...interface{}) { w.inner.Errorf(format, args...) }
-func (w tRunWrapper[WT]) FailNow()                                  { w.inner.FailNow() }
-func (w tRunWrapper[WT]) Failed() bool                              { return w.inner.Failed() }
-func (w tRunWrapper[WT]) Fatal(args ...interface{})                 { w.inner.Fatal(args...) }
-func (w tRunWrapper[WT]) Fatalf(format string, args ...interface{}) { w.inner.Fatalf(format, args...) }
-func (w tRunWrapper[WT]) Helper()                                   { w.inner.Helper() }
-func (w tRunWrapper[WT]) Log(args ...interface{})                   { w.inner.Log(args...) }
-func (w tRunWrapper[WT]) Logf(format string, args ...interface{})   { w.inner.Logf(format, args...) }
-func (w tRunWrapper[WT]) Name() string                              { return w.inner.Name() }
-func (w tRunWrapper[WT]) Skip(args ...interface{})                  { w.inner.Skip(args...) }
-func (w tRunWrapper[WT]) Skipf(format string, args ...interface{})  { w.inner.Skipf(format, args...) }
-func (w tRunWrapper[WT]) Skipped() bool                             { return w.inner.Skipped() }
+func (w tRunWrapper[WT]) Fail()     { w.inner.Fail() }
+func (w tRunWrapper[WT]) Parallel() { w.inner.Parallel() }
 
 // AdjustSkipFrames forwards the skip frame adjustment to the inner wrapper if it supports it
+// tRunWrapper adds 0 frames (it just delegates all T methods directly)
 func (w tRunWrapper[WT]) AdjustSkipFrames(skip int) {
 	if adjuster, ok := any(w.inner).(interface{ AdjustSkipFrames(int) }); ok {
-		adjuster.AdjustSkipFrames(skip)
+		adjuster.AdjustSkipFrames(skip) // +0 since tRunWrapper doesn't add any frames
 	}
 }
 

--- a/t.go
+++ b/t.go
@@ -91,7 +91,7 @@ func (r runTHelper) Fail() {
 		failer.Fail()
 		return
 	}
-	// Fallback - most T implementations have some way to fail
+	// Fallback
 	r.T.FailNow()
 }
 
@@ -101,4 +101,18 @@ func (r runTHelper) Parallel() {
 		return
 	}
 	// If not supported, we just continue - parallel is optional
+}
+
+// RunWithReWrap is a helper that runs a subtest and automatically handles ReWrap logic
+// This reduces boilerplate in matrix testing
+func RunWithReWrap(t RunT, name string, f func(RunT)) bool {
+	return t.Run(name, func(subT *testing.T) {
+		var reWrapped RunT
+		if reWrapper, ok := t.(ReWrapper); ok {
+			reWrapped = NewTestRunner(reWrapper.ReWrap(subT))
+		} else {
+			reWrapped = NewTestRunner(subT)
+		}
+		f(reWrapped)
+	})
 }

--- a/t.go
+++ b/t.go
@@ -50,16 +50,6 @@ func (s simpleRunT[ET]) Run(name string, f func(ET)) bool {
 	return false
 }
 
-// Runner provides RunT functionality without specific type constraints.
-// This allows functions to return a type that can be used with matrix testing
-// without exposing the concrete wrapper types.
-type Runner interface {
-	T
-	Run(string, func(T)) bool
-	Fail()
-	Parallel()
-}
-
 // tRunWrapper wraps any RunT[WT] to implement RunT[T]
 type tRunWrapper[WT T] struct {
 	T

--- a/t.go
+++ b/t.go
@@ -21,3 +21,131 @@ type T interface {
 	Skipf(format string, args ...interface{})
 	Skipped() bool
 }
+
+type RunT[GT T] interface {
+	T
+	Run(string, func(GT)) bool
+	Fail()
+	Parallel()
+}
+
+// Runner provides RunT functionality without specific type constraints.
+// This allows functions to return a type that can be used with matrix testing
+// without exposing the concrete wrapper types.
+type Runner interface {
+	T
+	Run(string, func(T)) bool
+	Fail()
+	Parallel()
+}
+
+// eitherT provides RunT functionality for wrapper types (internal use only)
+// WT is the wrapper type (like logWrappedT[ET])
+// ET is the underlying T type
+// This allows embedding types to automatically implement RunT[WT]
+type eitherT[WT any, ET T] struct {
+	t        ET
+	wrapFunc func(eitherT[WT, ET]) WT
+}
+
+func makeEitherT[WT any, ET T](t ET, wrapFunc func(eitherT[WT, ET]) WT) eitherT[WT, ET] {
+	return eitherT[WT, ET]{
+		t:        t,
+		wrapFunc: wrapFunc,
+	}
+}
+
+func makeEitherTSimple[ET T, WT any](t ET, wrapper WT) eitherT[WT, ET] {
+	return eitherT[WT, ET]{
+		t: t,
+		wrapFunc: func(eitherT[WT, ET]) WT {
+			return wrapper
+		},
+	}
+}
+
+func (t eitherT[WT, ET]) Run(name string, f func(WT)) bool {
+	if runT, ok := any(t.t).(RunT[ET]); ok {
+		return runT.Run(name, func(innerT ET) {
+			innerSelf := eitherT[WT, ET]{
+				t:        innerT,
+				wrapFunc: t.wrapFunc,
+			}
+			f(t.wrapFunc(innerSelf))
+		})
+	}
+	t.t.Logf("Run not supported by %T", t.t)
+	t.t.FailNow()
+	return false
+}
+
+func (t eitherT[WT, ET]) Fail() {
+	if runT, ok := any(t.t).(RunT[ET]); ok {
+		runT.Fail()
+		return
+	}
+	t.t.Logf("Fail not supported by %T", t.t)
+	t.t.FailNow()
+}
+
+func (t eitherT[WT, ET]) Parallel() {
+	if runT, ok := any(t.t).(RunT[ET]); ok {
+		runT.Parallel()
+		return
+	}
+	t.t.Logf("Parallel not supported by %T", t.t)
+	t.t.FailNow()
+}
+
+// Delegate all T methods
+func (t eitherT[WT, ET]) Cleanup(f func())                          { t.t.Cleanup(f) }
+func (t eitherT[WT, ET]) Setenv(key, value string)                  { t.t.Setenv(key, value) }
+func (t eitherT[WT, ET]) Error(args ...interface{})                 { t.t.Error(args...) }
+func (t eitherT[WT, ET]) Errorf(format string, args ...interface{}) { t.t.Errorf(format, args...) }
+func (t eitherT[WT, ET]) FailNow()                                  { t.t.FailNow() }
+func (t eitherT[WT, ET]) Failed() bool                              { return t.t.Failed() }
+func (t eitherT[WT, ET]) Fatal(args ...interface{})                 { t.t.Fatal(args...) }
+func (t eitherT[WT, ET]) Fatalf(format string, args ...interface{}) { t.t.Fatalf(format, args...) }
+func (t eitherT[WT, ET]) Helper()                                   { t.t.Helper() }
+func (t eitherT[WT, ET]) Log(args ...interface{})                   { t.t.Log(args...) }
+func (t eitherT[WT, ET]) Logf(format string, args ...interface{})   { t.t.Logf(format, args...) }
+func (t eitherT[WT, ET]) Name() string                              { return t.t.Name() }
+func (t eitherT[WT, ET]) Skip(args ...interface{})                  { t.t.Skip(args...) }
+func (t eitherT[WT, ET]) Skipf(format string, args ...interface{})  { t.t.Skipf(format, args...) }
+func (t eitherT[WT, ET]) Skipped() bool                             { return t.t.Skipped() }
+
+// tRunWrapper wraps any RunT[WT] to implement RunT[T]
+type tRunWrapper[WT T] struct {
+	inner RunT[WT]
+}
+
+func (w tRunWrapper[WT]) Run(name string, f func(T)) bool {
+	return w.inner.Run(name, func(wt WT) {
+		f(wt) // WT satisfies T, so this works
+	})
+}
+
+func (w tRunWrapper[WT]) Fail()                                     { w.inner.Fail() }
+func (w tRunWrapper[WT]) Parallel()                                 { w.inner.Parallel() }
+func (w tRunWrapper[WT]) Cleanup(f func())                          { w.inner.Cleanup(f) }
+func (w tRunWrapper[WT]) Setenv(key, value string)                  { w.inner.Setenv(key, value) }
+func (w tRunWrapper[WT]) Error(args ...interface{})                 { w.inner.Error(args...) }
+func (w tRunWrapper[WT]) Errorf(format string, args ...interface{}) { w.inner.Errorf(format, args...) }
+func (w tRunWrapper[WT]) FailNow()                                  { w.inner.FailNow() }
+func (w tRunWrapper[WT]) Failed() bool                              { return w.inner.Failed() }
+func (w tRunWrapper[WT]) Fatal(args ...interface{})                 { w.inner.Fatal(args...) }
+func (w tRunWrapper[WT]) Fatalf(format string, args ...interface{}) { w.inner.Fatalf(format, args...) }
+func (w tRunWrapper[WT]) Helper()                                   { w.inner.Helper() }
+func (w tRunWrapper[WT]) Log(args ...interface{})                   { w.inner.Log(args...) }
+func (w tRunWrapper[WT]) Logf(format string, args ...interface{})   { w.inner.Logf(format, args...) }
+func (w tRunWrapper[WT]) Name() string                              { return w.inner.Name() }
+func (w tRunWrapper[WT]) Skip(args ...interface{})                  { w.inner.Skip(args...) }
+func (w tRunWrapper[WT]) Skipf(format string, args ...interface{})  { w.inner.Skipf(format, args...) }
+func (w tRunWrapper[WT]) Skipped() bool                             { return w.inner.Skipped() }
+
+// AdjustSkipFrames forwards the skip frame adjustment to the inner wrapper if it supports it
+func (w tRunWrapper[WT]) AdjustSkipFrames(skip int) {
+	if adjuster, ok := any(w.inner).(interface{ AdjustSkipFrames(int) }); ok {
+		adjuster.AdjustSkipFrames(skip)
+	}
+}

--- a/t.go
+++ b/t.go
@@ -103,8 +103,9 @@ func (r runTHelper) Parallel() {
 	// If not supported, we just continue - parallel is optional
 }
 
-// RunWithReWrap is a helper that runs a subtest and automatically handles ReWrap logic
-// This reduces boilerplate in matrix testing
+// RunWithReWrap is a helper that runs a subtest and automatically handles ReWrap logic.
+// This should be used instead of calling t.Run in tests that use
+// ReplaceLogger, BufferedLogger, or ExtraDetailLogger.
 func RunWithReWrap(t RunT, name string, f func(RunT)) bool {
 	return t.Run(name, func(subT *testing.T) {
 		var reWrapped RunT

--- a/t.go
+++ b/t.go
@@ -84,3 +84,15 @@ func RunWithReWrap(t RunT, name string, f func(RunT)) bool {
 type ReWrapper interface {
 	ReWrap(T) T
 }
+
+// AsRunT upgrades a T to RunT for use with matrix testing.
+// Use this helper when you have a T and need to use it with matrix testing functions.
+func AsRunT[ET T](t ET) RunT {
+	// If t already implements RunT, return it directly
+	if runT, ok := any(t).(RunT); ok {
+		return runT
+	}
+
+	// Otherwise, wrap it using NewTestRunner
+	return NewTestRunner(t)
+}

--- a/t.go
+++ b/t.go
@@ -24,14 +24,21 @@ type T interface {
 	Skipped() bool
 }
 
+// RunT brings in more of the *testing.T API including Run and Parallel which are needed
+// for matrix tests.
+// *testing.T satisfies the RunT interface.
 type RunT interface {
 	T
 	Run(string, func(*testing.T)) bool
 	Parallel()
 }
 
-// NewTestRunner creates a test runner that works with matrix testing.
+// NewTestRunner creates a test runner that works with matrix testing by
+// upgrading a T to a RunT.
 // This is useful for converting T types to work with matrix testing functions.
+// If the concrete type underlying T doesn't implement Run then the
+// test will fail if Run is called. If the underlying type doesn't implement
+// Parallel, then the test won't be parallel.
 func NewTestRunner(t T) RunT {
 	if runT, ok := t.(RunT); ok {
 		return runT

--- a/t.go
+++ b/t.go
@@ -40,6 +40,7 @@ func RunWithReWrap(t T, name string, f func(T)) bool {
 	if !ok {
 		t.Logf("Run not supported by %T", t)
 		t.Fail()
+		return false
 	}
 	return runT.Run(name, func(subT *testing.T) {
 		var reWrapped T

--- a/test_test.go
+++ b/test_test.go
@@ -35,17 +35,17 @@ func TestParallelMatrixTestingT(t *testing.T) {
 }
 
 func TestParallelMatrixExtraDetail(t *testing.T) {
-	testParallelMatrixLogger(ntest.ExtraDetailLogger(t, "TPMED-"))
+	testParallelMatrixLogger(ntest.AsRunT(ntest.ExtraDetailLogger(t, "TPMED-")))
 }
 
 func TestParallelMatrixBuffered(t *testing.T) {
 	testRunTBasicLogger(ntest.AsRunT(ntest.BufferedLogger(t)))
 }
 
-func testRunTBasic(runT ntest.RunT[ntest.T]) {
-	// Simple test to verify RunT[T] functionality works
+func testRunTBasic(runT ntest.RunT) {
+	// Simple test to verify RunT functionality works
 	var ran bool
-	success := runT.Run("subtest", func(subT ntest.T) {
+	success := runT.Run("subtest", func(subT *testing.T) {
 		subT.Log("This is a subtest")
 		ran = true
 	})
@@ -54,19 +54,19 @@ func testRunTBasic(runT ntest.RunT[ntest.T]) {
 	}
 }
 
-func testRunTBasicLogger[ET ntest.T](runT ntest.RunT[ntest.LoggerT[ET]]) {
-	// Simple test to verify RunT[LoggerT[ET]] functionality works
+func testRunTBasicLogger(runT ntest.RunT) {
+	// Simple test to verify RunT functionality works
 	var ran bool
-	success := runT.Run("subtest", func(subT ntest.LoggerT[ET]) {
+	success := runT.Run("subtest", func(subT *testing.T) {
 		subT.Log("This is a subtest")
 		ran = true
 	})
 	if !success || !ran {
-		runT.Fatal("RunT[LoggerT[ET]] functionality failed")
+		runT.Fatal("RunT functionality failed")
 	}
 }
 
-func testParallelMatrix[ET ntest.RunT[ET]](t ET) {
+func testParallelMatrix(t ntest.RunT) {
 	var mu sync.Mutex
 	name := t.Name()
 	doneA := make(chan struct{})
@@ -86,7 +86,7 @@ func testParallelMatrix[ET ntest.RunT[ET]](t ET) {
 				},
 			),
 		},
-		func(t ET, s string, c chan struct{}) {
+		func(t *testing.T, s string, c chan struct{}) {
 			t.Logf("final func for %s", t.Name())
 			t.Logf("s = %s", s)
 			mu.Lock()
@@ -95,7 +95,7 @@ func testParallelMatrix[ET ntest.RunT[ET]](t ET) {
 			close(c)
 		},
 	)
-	t.Run("validate", func(t ET) {
+	t.Run("validate", func(t *testing.T) {
 		t.Parallel()
 		select {
 		case <-doneA:
@@ -114,7 +114,7 @@ func testParallelMatrix[ET ntest.RunT[ET]](t ET) {
 	})
 }
 
-func testParallelMatrixLogger[ET ntest.T](t ntest.RunT[ntest.LoggerT[ET]]) {
+func testParallelMatrixLogger(t ntest.RunT) {
 	// Simple test to verify the logger wrapper works
 	t.Log("Testing logger wrapper functionality")
 	t.Logf("Logger wrapper test for type %T", t)

--- a/test_test.go
+++ b/test_test.go
@@ -182,7 +182,7 @@ func TestExtra(t *testing.T) {
 
 func TestEmptyMatrix(t *testing.T) {
 	t.Parallel()
-	mk := newMockedT(t.Name())
+	mk := newMockedT(t)
 	ntest.RunMatrix(ntest.AsRunT(mk),
 		func() int { return 7 },
 		func(t *testing.T, i int) {
@@ -234,7 +234,7 @@ func TestLoggerRun(t *testing.T) {
 	t.Parallel()
 
 	// Create a mock T that doesn't support Run to test fallback behavior
-	mockT := newMockedT(t.Name())
+	mockT := newMockedT(t)
 	logger := ntest.ExtraDetailLogger(mockT, "TEST-")
 
 	// Capture log output to verify the "Run not supported" message
@@ -265,7 +265,7 @@ func TestSimpleRunTFallbacks(t *testing.T) {
 	t.Parallel()
 
 	// Test with a mock T that doesn't support Run or Parallel
-	mockT := newMockedT("TestSimpleRunTFallbacks")
+	mockT := newMockedT(t)
 	runT := ntest.NewTestRunner(mockT)
 
 	// Test Run fallback - should log error and fail

--- a/test_test.go
+++ b/test_test.go
@@ -35,11 +35,11 @@ func TestParallelMatrixTestingT(t *testing.T) {
 }
 
 func TestParallelMatrixExtraDetail(t *testing.T) {
-	testParallelMatrix(ntest.ExtraDetailLogger(t, "TPMED-"))
+	testParallelMatrixLogger(ntest.ExtraDetailLogger(t, "TPMED-"))
 }
 
 func TestParallelMatrixBuffered(t *testing.T) {
-	testRunTBasic(ntest.BufferedLogger(t))
+	testRunTBasicLogger(ntest.BufferedLogger(t))
 }
 
 func testRunTBasic(runT ntest.RunT[ntest.T]) {
@@ -51,6 +51,18 @@ func testRunTBasic(runT ntest.RunT[ntest.T]) {
 	})
 	if !success || !ran {
 		runT.Fatal("RunT functionality failed")
+	}
+}
+
+func testRunTBasicLogger[ET ntest.T](runT ntest.RunT[ntest.LoggerT[ET]]) {
+	// Simple test to verify RunT[LoggerT[ET]] functionality works
+	var ran bool
+	success := runT.Run("subtest", func(subT ntest.LoggerT[ET]) {
+		subT.Log("This is a subtest")
+		ran = true
+	})
+	if !success || !ran {
+		runT.Fatal("RunT[LoggerT[ET]] functionality failed")
 	}
 }
 
@@ -100,6 +112,12 @@ func testParallelMatrix[ET ntest.RunT[ET]](t ET) {
 			name + "/testB": {},
 		}, testsRun)
 	})
+}
+
+func testParallelMatrixLogger[ET ntest.T](t ntest.RunT[ntest.LoggerT[ET]]) {
+	// Simple test to verify the logger wrapper works
+	t.Log("Testing logger wrapper functionality")
+	t.Logf("Logger wrapper test for type %T", t)
 }
 
 func TestMatrix(t *testing.T) {

--- a/test_test.go
+++ b/test_test.go
@@ -79,12 +79,12 @@ func testParallelMatrix(t ntest.RunT) {
 		t.Parallel()
 		select {
 		case <-doneA:
-		case <-time.After(time.Second):
+		case <-time.After(time.Second * 2):
 			require.False(t, true, "timeout")
 		}
 		select {
 		case <-doneB:
-		case <-time.After(time.Second):
+		case <-time.After(time.Second * 2):
 			require.False(t, true, "timeout")
 		}
 		assert.Equal(t, map[string]struct{}{
@@ -126,12 +126,12 @@ func testParallelMatrixLogger(t ntest.RunT) {
 		subT.Parallel()
 		select {
 		case <-doneA:
-		case <-time.After(time.Second):
+		case <-time.After(time.Second * 2):
 			require.False(subT, true, "loggerA timeout")
 		}
 		select {
 		case <-doneB:
-		case <-time.After(time.Second):
+		case <-time.After(time.Second * 2):
 			require.False(subT, true, "loggerB timeout")
 		}
 	})

--- a/test_test.go
+++ b/test_test.go
@@ -46,18 +46,6 @@ func TestParallelMatrixExtraBuffered(t *testing.T) {
 	testRunTBasicLogger(ntest.AsRunT(ntest.ExtraDetailLogger(ntest.BufferedLogger(t), "TPMEB-")))
 }
 
-func testRunTBasic(runT ntest.RunT) {
-	// Simple test to verify RunT functionality works
-	var ran bool
-	success := runT.Run("subtest", func(subT *testing.T) {
-		subT.Log("This is a subtest")
-		ran = true
-	})
-	if !success || !ran {
-		runT.Fatal("RunT functionality failed")
-	}
-}
-
 func testRunTBasicLogger(runT ntest.RunT) {
 	// Simple test to verify RunT functionality works
 	var ran bool

--- a/test_test.go
+++ b/test_test.go
@@ -81,12 +81,12 @@ func testParallelMatrix(justT ntest.T) {
 		t.Parallel()
 		select {
 		case <-doneA:
-		case <-time.After(time.Second * 2):
+		case <-time.After(time.Second * 5):
 			require.False(t, true, "timeout")
 		}
 		select {
 		case <-doneB:
-		case <-time.After(time.Second * 2):
+		case <-time.After(time.Second * 5):
 			require.False(t, true, "timeout")
 		}
 		assert.Equal(t, map[string]struct{}{
@@ -131,12 +131,12 @@ func testParallelMatrixLogger(justT ntest.T) {
 		subT.Parallel()
 		select {
 		case <-doneA:
-		case <-time.After(time.Second * 2):
+		case <-time.After(time.Second * 5):
 			require.False(subT, true, "loggerA timeout")
 		}
 		select {
 		case <-doneB:
-		case <-time.After(time.Second * 2):
+		case <-time.After(time.Second * 5):
 			require.False(subT, true, "loggerB timeout")
 		}
 	})

--- a/test_test.go
+++ b/test_test.go
@@ -39,7 +39,7 @@ func TestParallelMatrixExtraDetail(t *testing.T) {
 }
 
 func TestParallelMatrixBuffered(t *testing.T) {
-	testRunTBasicLogger(ntest.BufferedLogger(t))
+	testRunTBasicLogger(ntest.AsRunT(ntest.BufferedLogger(t)))
 }
 
 func testRunTBasic(runT ntest.RunT[ntest.T]) {

--- a/test_test.go
+++ b/test_test.go
@@ -42,6 +42,10 @@ func TestParallelMatrixBuffered(t *testing.T) {
 	testRunTBasicLogger(ntest.AsRunT(ntest.BufferedLogger(t)))
 }
 
+func TestParallelMatrixExtraBuffered(t *testing.T) {
+	testRunTBasicLogger(ntest.AsRunT(ntest.ExtraDetailLogger(ntest.BufferedLogger(t), "TPMEB-")))
+}
+
 func testRunTBasic(runT ntest.RunT) {
 	// Simple test to verify RunT functionality works
 	var ran bool


### PR DESCRIPTION
This changes the log wrappers and adds multiple new public APIs. The general idea is to allow BufferedLogger and the other logger variants to work with matrix tests.

BREAKING CHANGE: the `T` interface has been expanded by adding `Parallel()` and `Fail()`. This can break additional implementations