### PR TITLE
[fix] remove Parallel() from T (BREAKING CHANGE)

### DIFF
--- a/matrix.go
+++ b/matrix.go
@@ -25,7 +25,6 @@ import (
 //
 // The provided T must support Run()
 func RunParallelMatrix(t T, chain ...any) {
-	t.Parallel()
 	runMatrixTest(t, true, chain)
 }
 
@@ -65,7 +64,7 @@ func runMatrixTest(t T, parallel bool, chain []any) {
 			subChain := subChain
 			RunWithReWrap(t, name, func(reWrapped T) {
 				if parallel {
-					reWrapped.Parallel()
+					Parallel(reWrapped)
 				}
 				testingT := func(tInner T) []any {
 					if tt, ok := tInner.(*testing.T); ok {


### PR DESCRIPTION
The prior breaking change that added `.Parallel()` to `T` caused a problem.  (It broke something)
This reverts that part of the prior change and adds a `Parallel(t)` function that calls an underlying `.Parallel()` if its supported.